### PR TITLE
Fix Disney+ mining pause bypass and subtitle auto-detection race

### DIFF
--- a/extension/src/entrypoints/disney-plus-page.ts
+++ b/extension/src/entrypoints/disney-plus-page.ts
@@ -150,13 +150,16 @@ export default defineUnlistedScript(() => {
     document.addEventListener(playEventName, () => disneyPlusPlayer()?.play());
     document.addEventListener(pauseEventName, () => disneyPlusPlayer()?.pause());
 
-    setTimeout(() => {
+    // Install the JSON.parse/Response.json hooks synchronously (not deferred behind a
+    // setTimeout) since Disney+'s own bundle can fire and parse its playback manifest
+    // request within the same tick the page script finishes loading. A deferred install
+    // here was losing that race intermittently, leaving lastM3U8Url/lastBasename unset and
+    // subtitle auto-detection silently failing.
+    {
         let lastM3U8Url: string | undefined = undefined;
         let lastBasename: string | undefined = undefined;
-        const originalParse = JSON.parse;
-        JSON.parse = function (...args: unknown[]) {
-            // @ts-expect-error: forwarding original parse arguments
-            const value = originalParse.apply(this, args);
+
+        const processParsedValue = (value: any) => {
             if (value?.stream?.sources instanceof Array && value.stream.sources.length > 0) {
                 const url = value.stream.sources[0].complete?.url;
 
@@ -171,8 +174,27 @@ export default defineUnlistedScript(() => {
                     lastBasename += ` ${value?.data?.playerExperience?.subtitle}`;
                 }
             }
+        };
+
+        const originalParse = JSON.parse;
+        JSON.parse = function (...args: unknown[]) {
+            // @ts-expect-error: forwarding original parse arguments
+            const value = originalParse.apply(this, args);
+            processParsedValue(value);
             return value;
         };
+
+        // Response.prototype.json() is served by an internal parser that never calls the
+        // patched JSON.parse above, so hook it directly too in case Disney+ fetches the
+        // manifest that way in some region/experiment variant.
+        const originalResponseJson = Response.prototype.json;
+        Response.prototype.json = function (this: Response) {
+            return originalResponseJson.call(this).then((value: any) => {
+                processParsedValue(value);
+                return value;
+            });
+        };
+
         inferTracks(
             {
                 onRequest: async (addTrack, setBasename) => {
@@ -192,5 +214,5 @@ export default defineUnlistedScript(() => {
             },
             60_000
         );
-    }, 0);
+    }
 });

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -696,7 +696,7 @@ export default class Binding {
 
         this.subtitleController.onMouseOver = (mouseEvent: MouseEvent) => {
             if (this.pauseOnHoverMode !== PauseOnHoverMode.disabled && !this.video.paused) {
-                this.video.pause();
+                this.pause();
                 this.pausedDueToHover = true;
 
                 if (this.mouseMoveListener) {
@@ -974,7 +974,7 @@ export default class Binding {
                         switch (this.postMinePlayback) {
                             case PostMinePlayback.remember:
                                 if (!this.wasPlayingBeforeRecordingMedia) {
-                                    this.video.pause();
+                                    this.pause();
                                 } else if (!this.video.paused) {
                                     this.mobileVideoOverlayController.hide();
                                 }
@@ -984,7 +984,7 @@ export default class Binding {
                                 this.mobileVideoOverlayController.hide();
                                 break;
                             case PostMinePlayback.pause:
-                                this.video.pause();
+                                this.pause();
                                 break;
                         }
                         break;


### PR DESCRIPTION
## Summary
- `recording-finished` and the subtitle-hover auto-pause called `this.video.pause()` directly, bypassing the Disney+/Netflix player-API dispatch that `pause()` already provides for seek/play. Route both through `pause()` for consistency.
- Disney+'s subtitle auto-detection hook (`JSON.parse`/manifest interception in `disney-plus-page.ts`) was installed behind a `setTimeout(0)`, which could lose the race against Disney+'s own bundle parsing its playback manifest on the same tick, silently leaving `lastM3U8Url`/`lastBasename` unset. Install the hooks synchronously instead, and additionally patch `Response.prototype.json` (its internal parser never calls the patched `JSON.parse`) as defensive coverage.

## Test plan
- [x] `yarn workspace @project/extension test` (43 tests passing)
- [x] `yarn workspace @project/extension compile` (tsc --noEmit, no errors)
- [x] `yarn workspace @project/extension dev` build succeeds
- [x] Manually verified via chrome-devtools-mcp against live Disney+ playback: player-API seek/pause/resume sequence holds up across a simulated mining cycle (seek → wait → play → pause → resume) with no drift in `player.timeline.info.playheadPositionMs` vs wall clock
- [ ] Would appreciate a maintainer/community check on real-world subtitle auto-detection reliability improvement, since the underlying race is timing-dependent and hard to guarantee eliminated in CI

Assisted-by: Claude:claude-sonnet-5