### PR TITLE
Feature: a simple solution helps Yomitan pick up a full sentence when a sentence spans multiple subtitles

### DIFF
--- a/extension/src/controllers/subtitle-controller.test.ts
+++ b/extension/src/controllers/subtitle-controller.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals';
+import { IndexedSubtitleModel } from '@project/common';
+import { buildSubtitleContextText } from './subtitle-controller';
+
+const subtitle = (text: string, index: number): IndexedSubtitleModel => ({
+    text,
+    index,
+    start: index * 1000,
+    end: (index + 1) * 1000,
+    originalStart: index * 1000,
+    originalEnd: (index + 1) * 1000,
+    track: 0,
+});
+
+describe('buildSubtitleContextText', () => {
+    it('returns empty strings for single subtitle', () => {
+        const result = buildSubtitleContextText(0, [subtitle('A', 0)]);
+        expect(result).toEqual({ before: '', after: '' });
+    });
+
+    it('returns correct before and after text', () => {
+        const subs = [subtitle('A', 0), subtitle('B', 1), subtitle('C', 2)];
+        const result = buildSubtitleContextText(1, subs);
+        expect(result).toEqual({ before: 'A', after: 'C' });
+    });
+
+    it('trims trailing space from subtitle text', () => {
+        const subs = [subtitle('A ', 0), subtitle('B', 1)];
+        const result = buildSubtitleContextText(1, subs);
+        expect(result.before).toBe('A');
+    });
+
+    it('trims leading space from subtitle text', () => {
+        const subs = [subtitle('A', 0), subtitle(' B', 1)];
+        const result = buildSubtitleContextText(0, subs);
+        expect(result.after).toBe('B');
+    });
+
+    it('prevents double space at before boundary', () => {
+        const subs = [subtitle('A ', 0), subtitle('B', 1)];
+        const result = buildSubtitleContextText(1, subs);
+        expect(result.before).toBe('A');
+        expect(result.before).not.toMatch(/ {2}/);
+    });
+
+    it('prevents double space at after boundary', () => {
+        const subs = [subtitle('A', 0), subtitle(' B', 1)];
+        const result = buildSubtitleContextText(0, subs);
+        expect(result.after).toBe('B');
+        expect(result.after).not.toMatch(/ {2}/);
+    });
+
+    it('joins multiple before subtitles with single space', () => {
+        const subs = [subtitle('A', 0), subtitle('B', 1), subtitle('C', 2)];
+        const result = buildSubtitleContextText(2, subs);
+        expect(result.before).toBe('A B');
+    });
+
+    it('joins multiple after subtitles with single space', () => {
+        const subs = [subtitle('A', 0), subtitle('B', 1), subtitle('C', 2)];
+        const result = buildSubtitleContextText(0, subs);
+        expect(result.after).toBe('B C');
+    });
+});

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -630,11 +630,16 @@ export default class SubtitleController {
                             </div>
                         `;
                     } else {
-                        return this._buildTextHtml(
-                            subtitle.text,
-                            subtitle.track,
-                            rendered?.richText,
-                            rendered?.richTextOnHover
+                        const { before, after } = _buildSubtitleContextHtml(subtitle.index, this.subtitles);
+                        return (
+                            before +
+                            this._buildTextHtml(
+                                subtitle.text,
+                                subtitle.track,
+                                rendered?.richText,
+                                rendered?.richTextOnHover
+                            ) +
+                            after
                         );
                     }
                 },
@@ -900,4 +905,26 @@ export default class SubtitleController {
 
         return false;
     }
+}
+
+export function buildSubtitleContextText(currentSubtitleIndex: number, subtitles: IndexedSubtitleModel[]) {
+    const beforeSubtitles = subtitles.slice(0, currentSubtitleIndex);
+    const afterSubtitles = subtitles.slice(currentSubtitleIndex + 1);
+
+    const fullBeforeText = beforeSubtitles.map((s) => s.text.trim()).join(' ');
+    const fullAfterText = afterSubtitles.map((s) => s.text.trim()).join(' ');
+
+    return {
+        before: fullBeforeText.substring(fullBeforeText.length - 500),
+        after: fullAfterText.substring(0, 500),
+    };
+}
+
+function _buildSubtitleContextHtml(currentSubtitleIndex: number, subtitles: IndexedSubtitleModel[]) {
+    const { before, after } = buildSubtitleContextText(currentSubtitleIndex, subtitles);
+
+    return {
+        before: `<span class="asbplayer-subtitle-context" style="width:0;height:0;overflow:hidden;display:inline-block">${before}</span>`,
+        after: `<span class="asbplayer-subtitle-context" style="width:0;height:0;overflow:hidden;display:inline-block">${after}</span>`,
+    };
 }


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

# Why
This change helps **Yomitan** to be able to pick up a full sentence when a sentence is broken up between subtitles.

# How
I added the previous subtitle text and the after subtitle text as a hidden span for Yomitan to pick up. Now it is just a prototype. I haven't added any settings to configure this functionality.

----
I don't know whether this is a good direction to solve this problem, but now it works quite well for me. Feel free to provide any advice to help solve this problem.

# Related
Partially related to: #640, #1059, etc.