### PR TITLE
redact exports ankiConnectApiKey and dictionaryWaniKaniApiToken

### DIFF
--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -1218,29 +1218,36 @@ const DictionarySettingsTab: React.FC<Props> = ({
                             </Typography>
                         )}
                         <Stack spacing={1}>
-                            <SwitchLabelWithHoverEffect
-                                control={
-                                    <Switch
-                                        checked={selectedDictionary.dictionaryTokenAnnotationConfig.colorizeEnabled}
-                                        onChange={(e) => {
-                                            const colorizeEnabled = e.target.checked;
-                                            const newTracks = [...dictionaryTracks];
-                                            newTracks[selectedDictionaryTrack] = {
-                                                ...newTracks[selectedDictionaryTrack],
-                                                dictionaryColorizeSubtitles: colorizeEnabled,
-                                                dictionaryTokenAnnotationConfig: {
-                                                    ...newTracks[selectedDictionaryTrack]
-                                                        .dictionaryTokenAnnotationConfig,
-                                                    colorizeEnabled,
-                                                },
-                                            };
-                                            void onSettingChanged('dictionaryTracks', newTracks);
-                                        }}
-                                    />
-                                }
-                                label={t('settings.dictionaryColorizeSubtitles')}
-                                labelPlacement="start"
-                            />
+                            <Box sx={{ display: 'flex', width: '100%' }}>
+                                <KeyboardShortcutLink
+                                    onClick={onViewKeyboardShortcuts}
+                                    sx={{ display: 'inline-block', ml: -1 }}
+                                />
+                                <SwitchLabelWithHoverEffect
+                                    sx={{ flexGrow: 1 }}
+                                    control={
+                                        <Switch
+                                            checked={selectedDictionary.dictionaryTokenAnnotationConfig.colorizeEnabled}
+                                            onChange={(e) => {
+                                                const colorizeEnabled = e.target.checked;
+                                                const newTracks = [...dictionaryTracks];
+                                                newTracks[selectedDictionaryTrack] = {
+                                                    ...newTracks[selectedDictionaryTrack],
+                                                    dictionaryColorizeSubtitles: colorizeEnabled,
+                                                    dictionaryTokenAnnotationConfig: {
+                                                        ...newTracks[selectedDictionaryTrack]
+                                                            .dictionaryTokenAnnotationConfig,
+                                                        colorizeEnabled,
+                                                    },
+                                                };
+                                                void onSettingChanged('dictionaryTracks', newTracks);
+                                            }}
+                                        />
+                                    }
+                                    label={t('settings.dictionaryColorizeSubtitles')}
+                                    labelPlacement="start"
+                                />
+                            </Box>
                             <Box sx={{ display: 'flex', width: '100%' }}>
                                 <KeyboardShortcutLink
                                     onClick={onViewKeyboardShortcuts}

--- a/common/components/KeyboardShortcutLink.tsx
+++ b/common/components/KeyboardShortcutLink.tsx
@@ -30,7 +30,7 @@ const presets: Record<Preset, PresetValue> = {
         },
     },
     formLabel: {
-        box: {},
+        box: { ml: 1 },
         iconButton: {
             size: 'small',
             disableRipple: true,

--- a/common/components/MiscSettingsTab.tsx
+++ b/common/components/MiscSettingsTab.tsx
@@ -20,6 +20,7 @@ import {
     exportSettings,
     isTrackAutoCopyable,
     isTrackSeekable,
+    mergeImportedSettings,
     PauseOnHoverMode,
     updateAutoCopyableTracksValue,
     updateSeekableTracksValue,
@@ -164,12 +165,12 @@ const MiscSettingTab: React.FC<Props> = ({
             }
 
             const importedSettings = JSON.parse(await file.text());
-            const validatedSettings = validateSettings(importedSettings);
+            const validatedSettings = validateSettings(mergeImportedSettings(importedSettings, settings));
             onSettingsChanged(validatedSettings);
         } catch (e) {
             asbError('settings/import', e);
         }
-    }, [onSettingsChanged]);
+    }, [onSettingsChanged, settings]);
 
     const handleImportSettings = useCallback(() => {
         settingsFileInputRef.current?.click();

--- a/common/settings/settings-import-export.test.ts
+++ b/common/settings/settings-import-export.test.ts
@@ -162,9 +162,10 @@ it('restores omitted credentials when importing a redacted export', () => {
         'wanikani-secret-1',
         'wanikani-secret-2',
     ]);
+    expect(importedSettings.streamingPages).toEqual(currentSettings.streamingPages);
 });
 
-it('does not restore credentials that are explicitly present in an import', () => {
+it('preserves current ignored values when they are explicitly present in an import', () => {
     const currentSettings = {
         ...defaultSettings,
         ankiConnectApiKey: 'existing-anki-secret',
@@ -180,12 +181,21 @@ it('does not restore credentials that are explicitly present in an import', () =
             ...track,
             dictionaryWaniKaniApiToken: '',
         })),
+        streamingPages: {
+            ...currentSettings.streamingPages,
+            netflix: { overrides: { autoSyncEnabled: true } },
+        },
     };
 
     const mergedSettings = mergeImportedSettings(importedSettings, currentSettings);
 
-    expect(mergedSettings.ankiConnectApiKey).toBe('');
-    expect(mergedSettings.dictionaryTracks?.map((track) => track.dictionaryWaniKaniApiToken)).toEqual(['', '', '']);
+    expect(mergedSettings.ankiConnectApiKey).toBe('existing-anki-secret');
+    expect(mergedSettings.dictionaryTracks?.map((track) => track.dictionaryWaniKaniApiToken)).toEqual([
+        'existing-wanikani-secret',
+        'existing-wanikani-secret',
+        'existing-wanikani-secret',
+    ]);
+    expect(mergedSettings.streamingPages?.netflix).toEqual(currentSettings.streamingPages.netflix);
 });
 
 it('validates exported settings', () => {

--- a/common/settings/settings-import-export.test.ts
+++ b/common/settings/settings-import-export.test.ts
@@ -7,9 +7,14 @@ import {
     TokenFrequencyAnnotation,
     VideoSubtitleSplitBehavior,
 } from '@project/common/settings/settings';
-import { validateSettings } from '@project/common/settings/settings-import-export';
+import {
+    mergeImportedSettings,
+    omitPath,
+    settingsForExport,
+    validateSettings,
+} from '@project/common/settings/settings-import-export';
 import { defaultSettings } from '@project/common/settings/settings-provider';
-import { expect, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { PlayMode } from '@project/common';
 
 it('validates the default settings', () => {
@@ -28,6 +33,159 @@ it('fails validation when an unknown key bind key is encountered', () => {
 
 it('validates last languages synced', () => {
     validateSettings({ ...defaultSettings, streamingLastLanguagesSynced: { 'domain.com': ['en', 'ja'] } });
+});
+
+describe('omitPath', () => {
+    it('removes a top-level key', () => {
+        const value = { keep: 'value', remove: 'secret' };
+
+        expect(omitPath(value, ['remove'])).toEqual({ keep: 'value' });
+    });
+
+    it('removes a nested key', () => {
+        const value = { outer: { keep: 'value', remove: 'secret' } };
+
+        expect(omitPath(value, ['outer', 'remove'])).toEqual({ outer: { keep: 'value' } });
+    });
+
+    it('applies a wildcard to every array item', () => {
+        const value = {
+            tracks: [
+                { keep: 'first', remove: 'first-secret' },
+                { keep: 'second', remove: 'second-secret' },
+            ],
+        };
+
+        expect(omitPath(value, ['tracks', '*', 'remove'])).toEqual({
+            tracks: [{ keep: 'first' }, { keep: 'second' }],
+        });
+    });
+
+    it('handles empty arrays and out-of-range indexes', () => {
+        const empty = { tracks: [] };
+        const populated = { tracks: [{ keep: 'value' }] };
+
+        expect(omitPath(empty, ['tracks', '*', 'remove'])).toEqual({ tracks: [] });
+        expect(omitPath(populated, ['tracks', '1', 'remove'])).toEqual(populated);
+    });
+
+    it('applies a path to one array index', () => {
+        const value = {
+            tracks: [
+                { keep: 'first', remove: 'first-secret' },
+                { keep: 'second', remove: 'second-secret' },
+                { keep: 'third', remove: 'third-secret' },
+            ],
+        };
+
+        expect(omitPath(value, ['tracks', '1', 'remove'])).toEqual({
+            tracks: [
+                { keep: 'first', remove: 'first-secret' },
+                { keep: 'second' },
+                { keep: 'third', remove: 'third-secret' },
+            ],
+        });
+    });
+
+    it('applies a wildcard to object values', () => {
+        const value = {
+            profiles: {
+                first: { keep: 'first', remove: 'first-secret' },
+                second: { keep: 'second', remove: 'second-secret' },
+            },
+        };
+
+        expect(omitPath(value, ['profiles', '*', 'remove'])).toEqual({
+            profiles: { first: { keep: 'first' }, second: { keep: 'second' } },
+        });
+    });
+
+    it('does not mutate the input', () => {
+        const value = { nested: { remove: 'secret' } };
+
+        omitPath(value, ['nested', 'remove']);
+
+        expect(value).toEqual({ nested: { remove: 'secret' } });
+    });
+
+    it('leaves values unchanged when the path cannot be traversed', () => {
+        const value = { nested: null, primitive: 'value' };
+
+        expect(omitPath(value, ['missing', 'key'])).toEqual(value);
+        expect(omitPath(value, ['nested', 'key'])).toEqual(value);
+        expect(omitPath(value, ['primitive', 'key'])).toEqual(value);
+        expect(omitPath(value, [])).toBe(value);
+    });
+});
+
+it('excludes credentials from settings exports without mutating the settings', () => {
+    const settings = {
+        ...defaultSettings,
+        ankiConnectApiKey: 'anki-secret',
+        dictionaryTracks: defaultSettings.dictionaryTracks.map((track, index) => ({
+            ...track,
+            dictionaryWaniKaniApiToken: `wanikani-secret-${index}`,
+        })),
+    };
+
+    const exportedSettings = settingsForExport(settings);
+
+    expect(exportedSettings).not.toHaveProperty('ankiConnectApiKey');
+    expect(exportedSettings).not.toHaveProperty('streamingPages');
+    expect(exportedSettings.dictionaryTracks).toHaveLength(3);
+    expect(exportedSettings.dictionaryTracks).toEqual([
+        expect.not.objectContaining({ dictionaryWaniKaniApiToken: expect.any(String) }),
+        expect.not.objectContaining({ dictionaryWaniKaniApiToken: expect.any(String) }),
+        expect.not.objectContaining({ dictionaryWaniKaniApiToken: expect.any(String) }),
+    ]);
+    expect(settings.ankiConnectApiKey).toBe('anki-secret');
+    expect(settings.dictionaryTracks[0].dictionaryWaniKaniApiToken).toBe('wanikani-secret-0');
+});
+
+it('restores omitted credentials when importing a redacted export', () => {
+    const currentSettings = {
+        ...defaultSettings,
+        ankiConnectApiKey: 'anki-secret',
+        dictionaryTracks: defaultSettings.dictionaryTracks.map((track, index) => ({
+            ...track,
+            dictionaryWaniKaniApiToken: `wanikani-secret-${index}`,
+        })),
+    };
+    const exportedSettings = settingsForExport(currentSettings);
+
+    const importedSettings = mergeImportedSettings(exportedSettings, currentSettings);
+    const validatedSettings = validateSettings(importedSettings);
+
+    expect(validatedSettings.ankiConnectApiKey).toBe('anki-secret');
+    expect(validatedSettings.dictionaryTracks?.map((track) => track.dictionaryWaniKaniApiToken)).toEqual([
+        'wanikani-secret-0',
+        'wanikani-secret-1',
+        'wanikani-secret-2',
+    ]);
+});
+
+it('does not restore credentials that are explicitly present in an import', () => {
+    const currentSettings = {
+        ...defaultSettings,
+        ankiConnectApiKey: 'existing-anki-secret',
+        dictionaryTracks: defaultSettings.dictionaryTracks.map((track) => ({
+            ...track,
+            dictionaryWaniKaniApiToken: 'existing-wanikani-secret',
+        })),
+    };
+    const importedSettings = {
+        ...settingsForExport(currentSettings),
+        ankiConnectApiKey: '',
+        dictionaryTracks: currentSettings.dictionaryTracks.map((track) => ({
+            ...track,
+            dictionaryWaniKaniApiToken: '',
+        })),
+    };
+
+    const mergedSettings = mergeImportedSettings(importedSettings, currentSettings);
+
+    expect(mergedSettings.ankiConnectApiKey).toBe('');
+    expect(mergedSettings.dictionaryTracks?.map((track) => track.dictionaryWaniKaniApiToken)).toEqual(['', '', '']);
 });
 
 it('validates exported settings', () => {

--- a/common/settings/settings-import-export.ts
+++ b/common/settings/settings-import-export.ts
@@ -727,27 +727,85 @@ const settingsSchema = {
     },
 };
 
-const ignoreKeys: (keyof AsbplayerSettings)[] = [
-    'streamingPages', // Ignored due to security risk (e.g. disable CSP)
-];
+export type IgnorePathSegment = string | '*';
+export type IgnorePath = readonly IgnorePathSegment[];
 
-const withIgnoredKeysRemoved = (settings: any) => {
-    const copy = { ...settings };
-    for (const ignoreKey of ignoreKeys) {
-        delete copy[ignoreKey];
+const ignorePaths: readonly IgnorePath[] = [
+    ['ankiConnectApiKey'],
+    ['dictionaryTracks', '*', 'dictionaryWaniKaniApiToken'],
+    ['streamingPages'], // Ignored due to security risk (e.g. disable CSP)
+];
+const validationIgnorePaths: readonly IgnorePath[] = [['streamingPages']];
+
+export const omitPath = (value: any, path: IgnorePath): any => {
+    if (value === null || typeof value !== 'object' || !path.length) return value;
+
+    const [segment, ...remainingPath] = path;
+    if (segment === '*') {
+        if (Array.isArray(value)) return value.map((item) => omitPath(item, remainingPath));
+        return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, omitPath(child, remainingPath)]));
+    }
+
+    const copy = Array.isArray(value) ? [...value] : { ...value };
+    if (!remainingPath.length) {
+        delete copy[segment];
+    } else if (segment in copy) {
+        copy[segment] = omitPath(copy[segment], remainingPath);
     }
     return copy;
 };
 
+const omitPaths = (settings: any, paths: readonly IgnorePath[]) =>
+    paths.reduce((settingsCopy, ignorePath) => omitPath(settingsCopy, ignorePath), settings);
+
+export const settingsForExport = (settings: AsbplayerSettings): Partial<AsbplayerSettings> => {
+    return omitPaths(settings, ignorePaths);
+};
+
+/**
+ * Redacted exports omit credentials. Restore those values from the current settings before validation so
+ * ensureConsistencyOnRead does not replace omitted values with their empty default.
+ */
+export const mergeImportedSettings = (
+    importedSettings: Partial<AsbplayerSettings>,
+    currentSettings: AsbplayerSettings
+): Partial<AsbplayerSettings> => {
+    const mergedSettings = { ...importedSettings };
+
+    if (!('ankiConnectApiKey' in importedSettings)) {
+        mergedSettings.ankiConnectApiKey = currentSettings.ankiConnectApiKey;
+    }
+
+    if (Array.isArray(importedSettings.dictionaryTracks)) {
+        mergedSettings.dictionaryTracks = importedSettings.dictionaryTracks.map((track, index) => {
+            const currentTrack = currentSettings.dictionaryTracks[index];
+            if (
+                track === null ||
+                typeof track !== 'object' ||
+                'dictionaryWaniKaniApiToken' in track ||
+                currentTrack === undefined
+            ) {
+                return track;
+            }
+            return {
+                ...(track as Record<string, unknown>),
+                dictionaryWaniKaniApiToken: currentTrack.dictionaryWaniKaniApiToken,
+            };
+        }) as AsbplayerSettings['dictionaryTracks'];
+    }
+
+    return mergedSettings;
+};
+
 export const exportSettings = (settings: AsbplayerSettings) => {
     download(
-        new Blob([JSON.stringify(withIgnoredKeysRemoved(settings))], { type: 'application/json' }),
+        new Blob([JSON.stringify(settingsForExport(settings))], { type: 'application/json' }),
         `asbplayer-settings-${getCurrentTimeString()}.json`
     );
 };
 
 export const validateSettings = (settings: any) => {
-    const copy = withIgnoredKeysRemoved(settings);
+    const copy = omitPaths(settings, validationIgnorePaths);
     const validator = new Validator();
     validator.addSchema(keyBindSchema);
     validator.addSchema(ankiFieldSchema);

--- a/common/settings/settings-import-export.ts
+++ b/common/settings/settings-import-export.ts
@@ -762,40 +762,42 @@ export const settingsForExport = (settings: AsbplayerSettings): Partial<Asbplaye
     return omitPaths(settings, ignorePaths);
 };
 
+const mergeIgnoredPath = (importedValue: any, currentValue: any, path: IgnorePath): any => {
+    if (importedValue === null || typeof importedValue !== 'object' || !path.length) return importedValue;
+
+    const [segment, ...remainingPath] = path;
+    if (segment === '*') {
+        if (Array.isArray(importedValue)) {
+            return importedValue.map((item, index) => mergeIgnoredPath(item, currentValue?.[index], remainingPath));
+        }
+        return Object.fromEntries(
+            Object.entries(importedValue).map(([key, value]) => [
+                key,
+                mergeIgnoredPath(value, currentValue?.[key], remainingPath),
+            ])
+        );
+    }
+
+    const mergedValue = Array.isArray(importedValue) ? [...importedValue] : { ...importedValue };
+    if (remainingPath.length && segment in importedValue) {
+        mergedValue[segment] = mergeIgnoredPath(importedValue[segment], currentValue?.[segment], remainingPath);
+    } else if (currentValue !== null && typeof currentValue === 'object' && segment in currentValue) {
+        mergedValue[segment] = currentValue[segment];
+    }
+    return mergedValue;
+};
+
 /**
- * Redacted exports omit credentials. Restore those values from the current settings before validation so
- * ensureConsistencyOnRead does not replace omitted values with their empty default.
+ * Restore ignored values from the current settings, regardless of whether they are present in an import.
  */
 export const mergeImportedSettings = (
     importedSettings: Partial<AsbplayerSettings>,
     currentSettings: AsbplayerSettings
-): Partial<AsbplayerSettings> => {
-    const mergedSettings = { ...importedSettings };
-
-    if (!('ankiConnectApiKey' in importedSettings)) {
-        mergedSettings.ankiConnectApiKey = currentSettings.ankiConnectApiKey;
-    }
-
-    if (Array.isArray(importedSettings.dictionaryTracks)) {
-        mergedSettings.dictionaryTracks = importedSettings.dictionaryTracks.map((track, index) => {
-            const currentTrack = currentSettings.dictionaryTracks[index];
-            if (
-                track === null ||
-                typeof track !== 'object' ||
-                'dictionaryWaniKaniApiToken' in track ||
-                currentTrack === undefined
-            ) {
-                return track;
-            }
-            return {
-                ...(track as Record<string, unknown>),
-                dictionaryWaniKaniApiToken: currentTrack.dictionaryWaniKaniApiToken,
-            };
-        }) as AsbplayerSettings['dictionaryTracks'];
-    }
-
-    return mergedSettings;
-};
+): Partial<AsbplayerSettings> =>
+    ignorePaths.reduce(
+        (mergedSettings, ignorePath) => mergeIgnoredPath(mergedSettings, currentSettings, ignorePath),
+        importedSettings
+    );
 
 export const exportSettings = (settings: AsbplayerSettings) => {
     download(


### PR DESCRIPTION
These two fields (especially for WaniKani) can leak sensitive information from users when sharing their config. It's best to simply never export these as they can always be easily retrieved from AnkiConnect or a regenerated WaniKani token.

This is implemented through a generalized ignore path which allows ignoring nested keys and through arrays. Even if the field exists in the imported json, we will ignore it and use the current settings.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
