### PR TITLE
Remove t dependency from VideoPlayer's playback engine

### DIFF
--- a/common/app/components/Alert.tsx
+++ b/common/app/components/Alert.tsx
@@ -65,9 +65,13 @@ interface LocalizableMessage {
     replacements: { [key: string]: any };
 }
 
+type LazyLocalizableMessage = (t: TFunction) => React.ReactNode;
+
+type Message = React.ReactNode | LocalizableMessage | LazyLocalizableMessage;
+
 export interface AlertNotification {
     key?: string;
-    message: React.ReactNode | LocalizableMessage;
+    message: Message;
     severity: AlertColor | undefined;
     autoHideDuration?: number;
 }
@@ -75,22 +79,33 @@ export interface AlertNotification {
 interface AlertNotificationValue {
     notificationKey?: string;
     autoHideResetKey: number;
-    children: React.ReactNode | LocalizableMessage;
+    children: React.ReactNode;
     severity: AlertColor | undefined;
     autoHideDuration?: number;
     disableAutoHide: boolean;
     open: boolean;
 }
 
+const messageToReactNode = (children: Message, t: TFunction): React.ReactNode => {
+    if (typeof children === 'object' && children !== null && 'locKey' in children) {
+        return t(children.locKey, children.replacements);
+    }
+    if (typeof children === 'function') {
+        return children(t);
+    }
+    return children;
+};
+
 function toAlertNotification(
     notification: AlertNotification,
     disableAutoHide: boolean | undefined,
-    autoHideResetKey: number
+    autoHideResetKey: number,
+    t: TFunction
 ): AlertNotificationValue {
     return {
         notificationKey: notification.key,
         autoHideResetKey,
-        children: notification.message,
+        children: messageToReactNode(notification.message, t),
         severity: notification.severity,
         autoHideDuration: notification.autoHideDuration,
         disableAutoHide: disableAutoHide ?? false,
@@ -109,13 +124,6 @@ interface AlertItemProps extends AlertNotificationValue {
     onMouseLeave?: () => void;
 }
 
-const tryLocalize = (children: React.ReactNode | LocalizableMessage, t: TFunction): React.ReactNode => {
-    if (typeof children === 'object' && children !== null && 'locKey' in children) {
-        return t(children.locKey, children.replacements);
-    }
-    return children;
-};
-
 function AlertItem({
     id,
     open,
@@ -131,7 +139,6 @@ function AlertItem({
     disableAutoHide,
 }: AlertItemProps) {
     const classes = useAlertStyles();
-    const { t } = useTranslation();
 
     useEffect(() => {
         if (!open || disableAutoHide) {
@@ -152,7 +159,7 @@ function AlertItem({
                     onMouseLeave={onMouseLeave}
                     style={{ pointerEvents: 'auto' }}
                 >
-                    {tryLocalize(children, t)}
+                    {children}
                 </MuiAlert>
             </Grow>
         </div>
@@ -238,10 +245,13 @@ export default function Alert(props: Props) {
     const initialRequestedNotifications = props.open
         ? deduplicateAlertNotifications(props.notifications ?? [{ message: props.children, severity: props.severity }])
         : [];
-    const initialNotifications = initialRequestedNotifications.map((notification, index) => ({
-        id: index,
-        value: toAlertNotification(notification, props.disableAutoHide, index),
-    }));
+    const { t } = useTranslation();
+    const initialNotifications = initialRequestedNotifications
+        .map((notification, index) => ({
+            id: index,
+            value: toAlertNotification(notification, props.disableAutoHide, index, t),
+        }))
+        .filter((notif) => !!notif.value.children);
     const [notifications, setNotifications] = useState<Stack<AlertNotificationValue>[]>(initialNotifications);
     const nextNotificationIdRef = useRef(initialNotifications.length);
     const previousPropsRef = useRef<readonly AlertNotification[] | undefined>(
@@ -282,14 +292,16 @@ export default function Alert(props: Props) {
 
         if (changed && currentNotifications.length > 0) {
             hadNotificationsRef.current = true;
-            const newNotifications = currentNotifications.map((notification) => {
-                const id = nextNotificationIdRef.current++;
-                return { id, value: toAlertNotification(notification, props.disableAutoHide, id) };
-            });
+            const newNotifications = currentNotifications
+                .map((notification) => {
+                    const id = nextNotificationIdRef.current++;
+                    return { id, value: toAlertNotification(notification, props.disableAutoHide, id, t) };
+                })
+                .filter((notif) => !!notif.value.children);
             setNotifications((current) => updateAlertNotificationStack(current, newNotifications));
         }
         previousPropsRef.current = currentNotifications;
-    }, [props.open, props.notifications, props.children, props.severity, props.disableAutoHide, notifications]);
+    }, [props.open, props.notifications, props.children, props.severity, props.disableAutoHide, notifications, t]);
 
     return (
         <AlertStack anchor={props.anchor}>

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -61,7 +61,7 @@ import { useSubtitleDomCache } from '../hooks/use-subtitle-dom-cache';
 import { useAppKeyBinder } from '../hooks/use-app-key-binder';
 import { Direction, useSwipe } from '../hooks/use-swipe';
 import './subtitles.css';
-import i18n from 'i18next';
+import i18n, { type TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { adjacentSubtitle } from '../../key-binder';
 import { usePlaybackPreferences } from '../hooks/use-playback-preferences';
@@ -518,13 +518,13 @@ export default function VideoPlayer({
         (transition: PlayModeTransition, options: PlaybackModeNotificationFormatOptions = {}): AlertNotification[] => {
             synchronizePlaybackModesRef.current(transition.modes);
             if (!transition.added.size && !transition.removed.size) return [];
-            return formatPlaybackModeNotifications(transition, t, options).map(({ key, text }) => ({
+            return formatPlaybackModeNotifications(transition, options).map(({ key, text }) => ({
                 key,
                 message: text,
                 severity: 'info',
             }));
         },
-        [t]
+        []
     );
 
     const handlePlaybackRateChanged = useCallback(
@@ -683,18 +683,21 @@ export default function VideoPlayer({
                     clock.rate = settings.playbackRate;
                     playerChannel.playbackRate(settings.playbackRate, false);
 
-                    const offsetAndRate = settings.notifications.offsetAndRate.map((notification) =>
-                        notification.type === 'message'
-                            ? notification.message
-                            : t(notification.notification.locKey, notification.notification.replacements)
-                    );
+                    const offsetAndRate = (_t: TFunction) =>
+                        settings.notifications.offsetAndRate
+                            .map((notification) =>
+                                notification.type === 'message'
+                                    ? notification.message
+                                    : _t(notification.notification.locKey, notification.notification.replacements)
+                            )
+                            .join(playbackModeNotificationJoin);
                     const playbackModeNotifications = handlePlaybackModesChanged(settings.playbackModeTransition, {
                         includeTransition: false,
                     });
                     const notifications: AlertNotification[] = [];
                     if (offsetAndRate.length) {
                         notifications.push({
-                            message: offsetAndRate.join(playbackModeNotificationJoin),
+                            message: offsetAndRate,
                             severity: 'info',
                             autoHideDuration: settings.autoHideDuration,
                         });
@@ -728,7 +731,6 @@ export default function VideoPlayer({
         handlePlaybackModesChanged,
         playerChannel,
         settingsProvider,
-        t,
         updatePlayerState,
         updateSubtitlesWithOffset,
         video,

--- a/common/playback/controllers/playback-mode-controller.test.ts
+++ b/common/playback/controllers/playback-mode-controller.test.ts
@@ -5,6 +5,7 @@ import PlaybackModeController, {
     playbackModesSummaryNotificationKey,
     playbackModeTransitionNotificationKey,
     playbackModesFromSettings,
+    PlaybackModeNotificationText,
 } from '@project/common/playback/controllers/playback-mode-controller';
 
 const sortedModes = (modes: Set<PlayMode>) => [...modes].sort((left, right) => left - right);
@@ -66,6 +67,16 @@ const modeSelectionCases: ModeSelectionCase[] = [
         expected: [PlayMode.fastForward, PlayMode.autoPause, PlayMode.repeat],
     },
 ];
+
+const resolvePlaybackModeNotificationText = (
+    text: PlaybackModeNotificationText['text'],
+    localizer: (locKey: string) => string
+) => (typeof text === 'string' ? text : text(localizer));
+
+const resolvePlaybackModeNotifications = (
+    notifications: PlaybackModeNotificationText[],
+    localizer: (locKey: string) => string
+) => notifications.map(({ key, text }) => ({ key, text: resolvePlaybackModeNotificationText(text, localizer) }));
 
 describe('playback mode selection', () => {
     it.each([
@@ -166,20 +177,16 @@ describe('playback mode selection', () => {
             removed: new Set([PlayMode.normal]),
         });
 
-        expect(
-            formatPlaybackModeNotifications(
-                transition,
-                (locKey) =>
-                    ({
-                        'settings.playbackModes': 'Playback Modes',
-                        'controls.normalMode': 'Normal',
-                        'controls.condensedMode': 'Condensed',
-                        'controls.autoPauseMode': 'Auto-pause',
-                        'controls.fastForwardMode': 'Fast-forward',
-                        'controls.repeatMode': 'Repeat',
-                    })[locKey] ?? locKey
-            )
-        ).toEqual([
+        let localize = (locKey: string) =>
+            ({
+                'settings.playbackModes': 'Playback Modes',
+                'controls.normalMode': 'Normal',
+                'controls.condensedMode': 'Condensed',
+                'controls.autoPauseMode': 'Auto-pause',
+                'controls.fastForwardMode': 'Fast-forward',
+                'controls.repeatMode': 'Repeat',
+            })[locKey] ?? locKey;
+        expect(resolvePlaybackModeNotifications(formatPlaybackModeNotifications(transition), localize)).toEqual([
             {
                 key: playbackModesSummaryNotificationKey,
                 text: 'Playback Modes: Fast-forward',
@@ -190,16 +197,20 @@ describe('playback mode selection', () => {
             },
         ]);
 
+        localize = (locKey: string) =>
+            ({
+                'settings.playbackModes': 'Playback Modes',
+                'controls.normalMode': 'Normal',
+                'controls.fastForwardMode': 'Fast-forward',
+            })[locKey] ?? locKey;
         expect(
-            formatPlaybackModeNotifications(
-                transition,
-                (locKey) =>
-                    ({
-                        'settings.playbackModes': 'Playback Modes',
-                        'controls.normalMode': 'Normal',
-                        'controls.fastForwardMode': 'Fast-forward',
-                    })[locKey] ?? locKey,
-                { includeTransition: false }
+            resolvePlaybackModeNotifications(
+                formatPlaybackModeNotifications(
+                    transition,
+
+                    { includeTransition: false }
+                ),
+                localize
             )
         ).toEqual([{ key: playbackModesSummaryNotificationKey, text: 'Playback Modes: Fast-forward' }]);
     });
@@ -226,10 +237,12 @@ describe('playback mode selection', () => {
             removed: new Set<PlayMode>(),
         };
 
-        expect(formatPlaybackModeNotifications(activeModes, localize)[0].text).toBe(
-            'Playback Modes: Condensed + Repeat'
-        );
-        expect(formatPlaybackModeNotifications(normalModes, localize)[0].text).toBe('Playback Modes: Normal');
+        expect(
+            resolvePlaybackModeNotificationText(formatPlaybackModeNotifications(activeModes)[0].text, localize)
+        ).toBe('Playback Modes: Condensed + Repeat');
+        expect(
+            resolvePlaybackModeNotificationText(formatPlaybackModeNotifications(normalModes)[0].text, localize)
+        ).toBe('Playback Modes: Normal');
     });
 
     it('preserves non-conflicting modes over multiple toggles', () => {
@@ -277,20 +290,16 @@ describe('playback mode selection', () => {
             added: new Set([PlayMode.normal]),
             removed: new Set([PlayMode.fastForward, PlayMode.repeat]),
         });
-        expect(
-            formatPlaybackModeNotifications(
-                transition,
-                (locKey) =>
-                    ({
-                        'settings.playbackModes': 'Playback Modes',
-                        'controls.normalMode': 'Normal',
-                        'controls.fastForwardMode': 'Fast-forward',
-                        'controls.repeatMode': 'Repeat',
-                        'info.disabledFastForwardPlayback': 'Fast-forward playback: Off',
-                        'info.disabledRepeatPlayback': 'Repeat playback: Off',
-                    })[locKey] ?? locKey
-            )
-        ).toEqual([
+        const localize = (locKey: string) =>
+            ({
+                'settings.playbackModes': 'Playback Modes',
+                'controls.normalMode': 'Normal',
+                'controls.fastForwardMode': 'Fast-forward',
+                'controls.repeatMode': 'Repeat',
+                'info.disabledFastForwardPlayback': 'Fast-forward playback: Off',
+                'info.disabledRepeatPlayback': 'Repeat playback: Off',
+            })[locKey] ?? locKey;
+        expect(resolvePlaybackModeNotifications(formatPlaybackModeNotifications(transition), localize)).toEqual([
             { key: playbackModesSummaryNotificationKey, text: 'Playback Modes: Normal' },
             {
                 key: playbackModeTransitionNotificationKey,

--- a/common/playback/controllers/playback-mode-controller.ts
+++ b/common/playback/controllers/playback-mode-controller.ts
@@ -25,9 +25,11 @@ export const playbackModeTransitionNotificationKey = 'playback-mode-transition';
 export const playbackModeNotificationJoin = ' | ';
 const playbackModesSummaryJoin = ' + ';
 
+type LazyLocalizableString = (localize: Localizer) => string;
+
 export interface PlaybackModeNotificationText {
     readonly key: string;
-    readonly text: string;
+    readonly text: string | LazyLocalizableString;
 }
 
 export interface PlaybackModeNotificationFormatOptions {
@@ -72,33 +74,36 @@ const playbackModesForSummary: readonly PlayMode[] = [
     PlayMode.repeat,
 ];
 
+type Localizer = (locKey: string) => string;
+
 export const formatPlaybackModeNotifications = (
     transition: PlayModeTransition,
-    localize: (locKey: string) => string,
     { includeTransition = true, summarySeparator = ': ' }: PlaybackModeNotificationFormatOptions = {}
 ): PlaybackModeNotificationText[] => {
-    const enabledModes = playbackModesForSummary
-        .filter((mode) => transition.modes.has(mode))
-        .map((mode) => localize(playbackModeLabelLocKey(mode)));
+    const enabledModes = playbackModesForSummary.filter((mode) => transition.modes.has(mode));
     const notifications: PlaybackModeNotificationText[] = [
         {
             key: playbackModesSummaryNotificationKey,
-            text: `${localize('settings.playbackModes')}${summarySeparator}${
-                enabledModes.length > 0
-                    ? enabledModes.join(playbackModesSummaryJoin)
-                    : localize(playbackModeLabelLocKey(PlayMode.normal))
-            }`,
+            text: (localize: Localizer) =>
+                `${localize('settings.playbackModes')}${summarySeparator}${
+                    enabledModes.length > 0
+                        ? enabledModes
+                              .map((mode) => localize(playbackModeLabelLocKey(mode)))
+                              .join(playbackModesSummaryJoin)
+                        : localize(playbackModeLabelLocKey(PlayMode.normal))
+                }`,
         },
     ];
     if (!includeTransition) return notifications;
 
-    const transitionText = [
-        ...[...transition.removed].map((mode) => playbackModeTransitionLocKey(mode, false)),
-        ...[...transition.added].map((mode) => playbackModeTransitionLocKey(mode, true)),
-    ]
-        .filter((locKey): locKey is string => locKey !== undefined)
-        .map(localize)
-        .join(playbackModeNotificationJoin);
+    const transitionText = (localize: Localizer) =>
+        [
+            ...[...transition.removed].map((mode) => playbackModeTransitionLocKey(mode, false)),
+            ...[...transition.added].map((mode) => playbackModeTransitionLocKey(mode, true)),
+        ]
+            .filter((locKey): locKey is string => locKey !== undefined)
+            .map(localize)
+            .join(playbackModeNotificationJoin);
     if (transitionText) {
         notifications.push({
             key: playbackModeTransitionNotificationKey,

--- a/extension/src/services/binding.test.ts
+++ b/extension/src/services/binding.test.ts
@@ -17,6 +17,9 @@ jest.mock('./localization-fetcher', () => ({
 jest.mock('./i18n', () => ({
     i18nInit: jest.fn(async () => undefined),
 }));
+jest.mock('i18next', () => ({
+    t: (key: string) => key,
+}));
 jest.mock('./build-flags', () => ({
     isFirefoxBuild: false,
 }));

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -366,11 +366,13 @@ export default class Binding {
         if (!transition.added.size && !transition.removed.size) return;
         this.mobileVideoOverlayController.setPlaybackModes(transition.modes);
         void this.mobileVideoOverlayController.updateModel();
-        return formatPlaybackModeNotifications(transition, (locKey) => i18n.t(locKey) ?? locKey, {
+        return formatPlaybackModeNotifications(transition, {
             ...options,
             summarySeparator: ':\n',
         })
-            .map((notification) => notification.text)
+            .map((notification) =>
+                typeof notification.text === 'string' ? notification.text : notification.text(i18n.t)
+            )
             .join('\n');
     }
 


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

I ran an AI review on v1.20.0 and got this comment:

> 2. Playback engine is torn down and recreated when the app language changes (common/app/components/VideoPlayer.tsx:722-734, :514-526)
The engine-creation effect lists t in deps (handlePlaybackModesChanged deps are [t]). react-i18next 15.6.1 swaps t on languageChanged, so changing the language mid-playback (VideoPlayer.tsx:448-452) unbinds and rebuilds the engine — re-applying offset/rate, re-firing initialPlaybackSettingsChanged notifications, and re-offering the resume prompt. v1.19.0's effect deps were stable.

I was able to reproduce the resume notification reappearing on language change. I went ahead and addressed the issue by introducing a lazily-localized string value to the playback notification type. The `Alert` supplies the `t` function for final rendering. 