### PR TITLE
Fix silent audio on first play and pause behavior in Firefox

### DIFF
--- a/common/audio-clip/audio-clip.ts
+++ b/common/audio-clip/audio-clip.ts
@@ -207,6 +207,7 @@ class FileAudioClipper {
     private readonly _recorderMimeType: string;
     private readonly _trackId?: string;
     private _clippingAudioElement?: HTMLAudioElement;
+    private _clippingAudioContext?: AudioContext;
     private _clippingAudibly?: boolean;
     private _clippingAudioReject?: (error: Error) => void;
     private _stopClippingTimeout?: ReturnType<typeof setTimeout>;
@@ -240,7 +241,7 @@ class FileAudioClipper {
 
     get isPlayingAudibly(): boolean {
         return (
-            (!isFirefox && this._clippingAudioElement !== undefined && this._clippingAudibly === true) ||
+            (this._clippingAudioElement !== undefined && this._clippingAudibly === true) ||
             this._playingAudioElement !== undefined
         );
     }
@@ -303,9 +304,16 @@ class FileAudioClipper {
                         if (!audible) {
                             // Direct audio to destination other than speakers
                             const audioContext = new AudioContext();
+                            this._clippingAudioContext = audioContext;
                             const destination = audioContext.createMediaStreamDestination();
                             const source = audioContext.createMediaElementSource(audio);
                             source.connect(destination);
+                        } else if (isFirefox) {
+                            // In Firefox, captureStream() mutes the media element audio to speakers unless connected to AudioContext destination
+                            const audioContext = new AudioContext();
+                            this._clippingAudioContext = audioContext;
+                            const source = audioContext.createMediaElementSource(audio);
+                            source.connect(audioContext.destination);
                         }
 
                         await audio.play();
@@ -338,6 +346,8 @@ class FileAudioClipper {
                         this._stopClippingTimeout = setTimeout(
                             () => {
                                 this._stopAudio(audio, false);
+                                void this._clippingAudioContext?.close();
+                                this._clippingAudioContext = undefined;
                                 this._clippingAudioElement = undefined;
                                 this._stopClippingTimeout = undefined;
                                 this._clippingAudioReject = undefined;
@@ -374,6 +384,8 @@ class FileAudioClipper {
         }
 
         this._stopAudio(this._clippingAudioElement, false);
+        void this._clippingAudioContext?.close();
+        this._clippingAudioContext = undefined;
         clearTimeout(this._stopClippingTimeout);
         this._clippingAudioReject?.(new ClippingCancelledError());
         this._clippingAudioElement = undefined;
@@ -530,7 +542,7 @@ class FileAudioData implements AudioData {
     }
 
     get playing() {
-        return this._playClipper?.isPlayingAudibly ?? false;
+        return this._blobClipper.isPlayingAudibly || (this._playClipper?.isPlayingAudibly ?? false);
     }
 
     onEvent(event: AudioClipEvent, callback: () => void) {


### PR DESCRIPTION
Fixing #1062 

Assisted-by: Gemini:gemini-3.7-flash

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

### Summary of Changes

Fixes an issue where playing an unrecorded audio clip for the first time in the popup dialog produces silent audio in Firefox, and mid-playback pause does not work.

### Root Cause
1. **Firefox Mutes Media Elements on Stream Capture**: When `captureStream()` / `mozCaptureStream()` is called on an `<audio>` element in Firefox during the first live clipping pass, Firefox redirects audio into the stream and detaches/mutes the audio output from the speakers.
2. **Audio State Tracking**: `isPlayingAudibly` had a `!isFirefox` check, and `FileAudioData.playing` only inspected `_playClipper?.isPlayingAudibly` without including `_blobClipper.isPlayingAudibly`. This caused `playing` to falsely report `false` during live clipping, preventing the pause action from functioning during the first pass.

### Solution
- Connected `createMediaElementSource(audio)` to `audioContext.destination` in Firefox during audible clipping passes to ensure audio routes to the speakers while being recorded, and closed the `AudioContext` upon stop/completion.
- Removed the `!isFirefox` restriction from `FileAudioClipper.isPlayingAudibly`.
- Updated `FileAudioData.playing` to track `this._blobClipper.isPlayingAudibly || this._playClipper?.isPlayingAudibly`.

Tested on youtube and self hosted the video player to confirm fixes. 