### PR TITLE
Organize keyboard shortcuts tweaks

### DIFF
--- a/common/components/DictionarySettingsTab.tsx
+++ b/common/components/DictionarySettingsTab.tsx
@@ -1045,10 +1045,7 @@ const DictionarySettingsTab: React.FC<Props> = ({
                     <div>
                         <SettingsSubSection>
                             {t('settings.dictionaryLocalWordDatabase')}
-                            <KeyboardShortcutLink
-                                onClick={onViewKeyboardShortcuts}
-                                sectionTitle={t('settings.annotation')}
-                            />
+                            <KeyboardShortcutLink onClick={onViewKeyboardShortcuts} />
                         </SettingsSubSection>
                         <Stack direction="row" spacing={1} alignItems="center">
                             <Button
@@ -1244,31 +1241,31 @@ const DictionarySettingsTab: React.FC<Props> = ({
                                 label={t('settings.dictionaryColorizeSubtitles')}
                                 labelPlacement="start"
                             />
-                            <SwitchLabelWithHoverEffect
-                                control={
-                                    <Switch
-                                        checked={selectedDictionary.dictionaryAutoGenerateStatistics}
-                                        onChange={(e) => {
-                                            const newTracks = [...dictionaryTracks];
-                                            newTracks[selectedDictionaryTrack] = {
-                                                ...newTracks[selectedDictionaryTrack],
-                                                dictionaryAutoGenerateStatistics: e.target.checked,
-                                            };
-                                            void onSettingChanged('dictionaryTracks', newTracks);
-                                        }}
-                                    />
-                                }
-                                label={
-                                    <>
-                                        {t('settings.dictionaryAutoGenerateStatistics')}
-                                        <KeyboardShortcutLink
-                                            onClick={onViewKeyboardShortcuts}
-                                            sectionTitle={t('settings.annotation')}
+                            <Box sx={{ display: 'flex', width: '100%' }}>
+                                <KeyboardShortcutLink
+                                    onClick={onViewKeyboardShortcuts}
+                                    sx={{ display: 'inline-block', ml: -1 }}
+                                />
+                                <SwitchLabelWithHoverEffect
+                                    sx={{ flexGrow: 1 }}
+                                    control={
+                                        <Switch
+                                            checked={selectedDictionary.dictionaryAutoGenerateStatistics}
+                                            onChange={(e) => {
+                                                const newTracks = [...dictionaryTracks];
+                                                newTracks[selectedDictionaryTrack] = {
+                                                    ...newTracks[selectedDictionaryTrack],
+                                                    dictionaryAutoGenerateStatistics: e.target.checked,
+                                                };
+                                                void onSettingChanged('dictionaryTracks', newTracks);
+                                            }}
                                         />
-                                    </>
-                                }
-                                labelPlacement="start"
-                            />
+                                    }
+                                    label={t('settings.dictionaryAutoGenerateStatistics')}
+                                    labelPlacement="start"
+                                />
+                            </Box>
+
                             {tokenAnnotationTriggerOptions.map(({ annotation, labelKey }) => {
                                 const value = tokenAnnotationSelectionOptionValues(
                                     tokenAnnotationSelection(

--- a/common/components/KeyboardShortcutLink.tsx
+++ b/common/components/KeyboardShortcutLink.tsx
@@ -1,6 +1,8 @@
 import KeyboardIcon from '@mui/icons-material/Keyboard';
-import Box, { type BoxProps } from '@mui/material/Box';
-import IconButton, { type IconButtonProps } from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import type { BoxProps } from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import type { IconButtonProps } from '@mui/material/IconButton';
 import type { SxProps, Theme } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
 import { useTranslation } from 'react-i18next';

--- a/common/components/KeyboardShortcutLink.tsx
+++ b/common/components/KeyboardShortcutLink.tsx
@@ -1,29 +1,68 @@
 import KeyboardIcon from '@mui/icons-material/Keyboard';
-import IconButton from '@mui/material/IconButton';
+import Box, { type BoxProps } from '@mui/material/Box';
+import IconButton, { type IconButtonProps } from '@mui/material/IconButton';
+import type { SxProps, Theme } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
+import { useTranslation } from 'react-i18next';
+
+type Preset = 'formLabel' | 'numericalInputLabel';
+type PresetValue = { iconButton: IconButtonProps; box: BoxProps };
 
 interface Props {
     onClick: () => void;
-    sectionTitle: string;
+    sx?: SxProps<Theme>;
+    preset?: Preset;
 }
 
-export default function KeyboardShortcutLink({ onClick, sectionTitle }: Props) {
+const presets: Record<Preset, PresetValue> = {
+    numericalInputLabel: {
+        box: { display: 'inline-block', ml: 1 },
+        iconButton: {
+            size: 'small',
+            disableRipple: true,
+            disableFocusRipple: true,
+            sx: {
+                p: 0,
+                mb: 0.3,
+            },
+        },
+    },
+    formLabel: {
+        box: {},
+        iconButton: {
+            size: 'small',
+            disableRipple: true,
+            disableFocusRipple: true,
+            sx: {
+                p: 0,
+            },
+        },
+    },
+};
+
+const emptyPreset: PresetValue = { iconButton: {}, box: {} };
+
+export default function KeyboardShortcutLink({ onClick, sx, preset }: Props) {
+    const presetValue = preset === undefined ? emptyPreset : presets[preset];
+    const { t } = useTranslation();
     return (
-        <Tooltip title={sectionTitle}>
-            <IconButton
-                type="button"
-                size="small"
-                color="inherit"
-                aria-label={sectionTitle}
-                onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    onClick();
-                }}
-                sx={{ ml: 0.5, p: 0.25, verticalAlign: 'middle' }}
-            >
-                <KeyboardIcon fontSize="small" />
-            </IconButton>
-        </Tooltip>
+        <Box sx={{ display: 'flex', ...presetValue.box, ...sx }}>
+            <Tooltip title={t('settings.keyboardShortcuts')}>
+                <IconButton
+                    sx={{ display: 'flex' }}
+                    type="button"
+                    color="inherit"
+                    aria-label={t('settings.keyboardShortcuts')}
+                    onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onClick();
+                    }}
+                    {...presetValue.iconButton}
+                >
+                    <KeyboardIcon />
+                </IconButton>
+            </Tooltip>
+        </Box>
     );
 }

--- a/common/components/MiscSettingsTab.tsx
+++ b/common/components/MiscSettingsTab.tsx
@@ -302,12 +302,9 @@ const MiscSettingTab: React.FC<Props> = ({
                 )}
                 {(!extensionInstalled || extensionSupportsSeekableTrackSetting) && (
                     <FormControl>
-                        <FormLabel component="legend">
+                        <FormLabel component="legend" sx={{ display: 'flex' }}>
                             {t('settings.seekableTracks')}
-                            <KeyboardShortcutLink
-                                onClick={onViewSubtitleKeyboardShortcuts}
-                                sectionTitle={t('settings.subtitles')}
-                            />
+                            <KeyboardShortcutLink onClick={onViewSubtitleKeyboardShortcuts} preset="formLabel" />
                         </FormLabel>
                         <FormGroup>
                             {[0, 1, 2].map((trackIndex) => {
@@ -466,10 +463,7 @@ const MiscSettingTab: React.FC<Props> = ({
                 )}
                 <SettingsSection>
                     {t('settings.playbackModes')}
-                    <KeyboardShortcutLink
-                        onClick={onViewPlaybackModeKeyboardShortcuts}
-                        sectionTitle={t('extension.settings.playback')}
-                    />
+                    <KeyboardShortcutLink onClick={onViewPlaybackModeKeyboardShortcuts} />
                 </SettingsSection>
                 {supportsPlaybackEngine && (
                     <>
@@ -480,7 +474,7 @@ const MiscSettingTab: React.FC<Props> = ({
                                     {t('settings.playbackRate')}
                                     <KeyboardShortcutLink
                                         onClick={onViewPlaybackRateKeyboardShortcuts}
-                                        sectionTitle={t('settings.playbackRate')}
+                                        preset="numericalInputLabel"
                                     />
                                 </>
                             }

--- a/common/components/SettingsSection.tsx
+++ b/common/components/SettingsSection.tsx
@@ -15,7 +15,11 @@ interface SubSectionProps {
 
 const SettingsSection = React.forwardRef<HTMLSpanElement, Props>(function SettingsSection({ children, docs }, ref) {
     return (
-        <Typography ref={ref} variant="h5" sx={{ fontWeight: 'bold', pb: 0.5, pt: 1 }}>
+        <Typography
+            ref={ref}
+            variant="h5"
+            sx={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', pb: 0.5, pt: 1, width: '100%' }}
+        >
             {children}
             {docs && (
                 <Link href={`https://docs.asbplayer.dev/${docs}`} target="_blank">
@@ -29,7 +33,7 @@ const SettingsSection = React.forwardRef<HTMLSpanElement, Props>(function Settin
 });
 
 export const SettingsSubSection: React.FC<SubSectionProps> = ({ children }) => (
-    <Typography variant="h6" sx={{ fontWeight: 'bold', pb: 0.5, pt: 1 }}>
+    <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', fontWeight: 'bold', pb: 0.5, pt: 1 }}>
         {children}
     </Typography>
 );

--- a/common/components/SubtitleAppearanceSettingsTab.tsx
+++ b/common/components/SubtitleAppearanceSettingsTab.tsx
@@ -493,10 +493,7 @@ const SubtitleAppearanceSettingsTab: React.FC<Props> = ({
                         label={
                             <>
                                 {t('settings.subtitlePositionOffset')}
-                                <KeyboardShortcutLink
-                                    onClick={onViewKeyboardShortcuts}
-                                    sectionTitle={t('settings.subtitles')}
-                                />
+                                <KeyboardShortcutLink onClick={onViewKeyboardShortcuts} preset="numericalInputLabel" />
                             </>
                         }
                         value={subtitlePositionOffset}
@@ -514,10 +511,7 @@ const SubtitleAppearanceSettingsTab: React.FC<Props> = ({
                         label={
                             <>
                                 {t('settings.topSubtitlePositionOffset')}
-                                <KeyboardShortcutLink
-                                    onClick={onViewKeyboardShortcuts}
-                                    sectionTitle={t('settings.subtitles')}
-                                />
+                                <KeyboardShortcutLink onClick={onViewKeyboardShortcuts} preset="numericalInputLabel" />
                             </>
                         }
                         value={topSubtitlePositionOffset}


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

These are proposed tweaks to https://github.com/asbplayer/asbplayer/pull/1125

- Instead of tooltip displaying the shortcut section, display "keyboard shortcuts." Displaying the section name can result in confusion e.g. hovering over the keyboard shortcut button and it displays "annotations" which at first seem unrelated. Similarly, if the shortcuts button is next to "generate statistics automatically," hovering over the shortcuts button would display "annotations" which at first glance seem unrelated both to shortcuts and to statistics. Simply displaying "keyboard shortcuts" felt like the easiest way to circumvent any confusion.
- Moved the shortcut button to the left of the "generate statistics" switch. If it's to the right, it's easier to accidentally hit the switch when instead you meant to hit the shortcut button, because the switch hitbox takes up the whole row.
- Minor styling tweaks across