### PR TITLE
Improvements for the generic parser informed by real world tests

### DIFF
--- a/common/components/VideoDataSyncDialog.tsx
+++ b/common/components/VideoDataSyncDialog.tsx
@@ -210,6 +210,7 @@ export default function VideoDataSyncDialog({
     const { t } = useTranslation();
     const [name, setName] = useState('');
     const [shouldRememberTrackChoices, setShouldRememberTrackChoices] = useState(false);
+    const [genericSubtitleParserChanged, setGenericSubtitleParserChanged] = useState(false);
     const trimmedName = name.trim();
     const classes = createClasses();
 
@@ -218,6 +219,10 @@ export default function VideoDataSyncDialog({
             setShouldRememberTrackChoices(defaultCheckboxState);
         }
     }, [open, defaultCheckboxState]);
+
+    useEffect(() => {
+        if (open) setGenericSubtitleParserChanged(false);
+    }, [open]);
 
     useEffect(() => {
         setName((name) => {
@@ -259,6 +264,11 @@ export default function VideoDataSyncDialog({
 
     function handleRememberTrackChoices() {
         setShouldRememberTrackChoices(!shouldRememberTrackChoices);
+    }
+
+    function handleGenericSubtitleParserChange(parse: GenericParseType) {
+        onGenericSubtitleParserChange?.(parse);
+        setGenericSubtitleParserChanged(true);
     }
 
     function allSelectedSubtitleTracks() {
@@ -524,7 +534,7 @@ export default function VideoDataSyncDialog({
                                                     checked={genericSubtitleParser !== 'off'}
                                                     disabled={genericSubtitleParser === 'aggressive'}
                                                     onChange={(event) =>
-                                                        onGenericSubtitleParserChange?.(
+                                                        handleGenericSubtitleParserChange(
                                                             event.target.checked ? 'base' : 'off'
                                                         )
                                                     }
@@ -548,7 +558,7 @@ export default function VideoDataSyncDialog({
                                                     <Switch
                                                         checked={genericSubtitleParser === 'aggressive'}
                                                         onChange={(event) =>
-                                                            onGenericSubtitleParserChange?.(
+                                                            handleGenericSubtitleParserChange(
                                                                 event.target.checked ? 'aggressive' : 'base'
                                                             )
                                                         }
@@ -567,12 +577,18 @@ export default function VideoDataSyncDialog({
                                         </Grid>
                                     )}
                                     <Grid item>
-                                        <Alert severity={isGenericPage ? 'warning' : 'info'}>
-                                            {t(
-                                                isGenericPage
-                                                    ? 'extension.videoDataSync.genericPageWarning'
-                                                    : 'extension.videoDataSync.genericPageInfo'
-                                            )}
+                                        <Alert
+                                            severity={
+                                                genericSubtitleParserChanged || !isGenericPage ? 'info' : 'warning'
+                                            }
+                                        >
+                                            {genericSubtitleParserChanged
+                                                ? t('info.refreshForChangesToTakeEffect')
+                                                : t(
+                                                      isGenericPage
+                                                          ? 'extension.videoDataSync.genericPageWarning'
+                                                          : 'extension.videoDataSync.genericPageInfo'
+                                                  )}
                                         </Alert>
                                     </Grid>
                                 </>

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -335,7 +335,8 @@
         "error": "Error: {{message}}",
         "errorNoMessage": "Error",
         "toggleSubtitlesShortcut": "Press \"{{keys}}\" to toggle subtitle display",
-        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range"
+        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Untertitel und Medien hierher ziehen oder <1>suchen</1>",

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Auto-detected subtitle tracks can be selected here. asbplayer does not know how to detect subtitles on every site. You can always load your own subtitle files."
         },
         "videoSelect": {

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -335,7 +335,8 @@
         "error": "Error: {{message}}",
         "errorNoMessage": "Error",
         "toggleSubtitlesShortcut": "Press \"{{keys}}\" to toggle subtitle display",
-        "manualMiningIntervalPrompt": "Use mining shortcut again"
+        "manualMiningIntervalPrompt": "Use mining shortcut again",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Drag and drop subtitle and media files, or <1>browse</1>.",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Auto-detected subtitle tracks can be selected here. asbplayer does not know how to detect subtitles on every site. You can always load your own subtitle files."
         },
         "videoSelect": {

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Las pistas de subtítulos autodetectadas pueden ser seleccionadas aquí. asbplayer no sabe cómo detectar subtítulos en cada sitio. Se puede cargar sus propios subtítulos."
         },
         "videoSelect": {

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -335,7 +335,8 @@
         "error": "Error: {{message}}",
         "errorNoMessage": "Error",
         "toggleSubtitlesShortcut": "Pulsa \"{{keys}}\" para activar/desactivar la visualización de subtítulos",
-        "manualMiningIntervalPrompt": "Volver a usar el acceso directo de minería"
+        "manualMiningIntervalPrompt": "Volver a usar el acceso directo de minería",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Arrastra archivos de medios y subtítulos o <1>explora</1>.",

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Automaattisesti havaitut tekstitysraidat voidaan valita täällä. asbplayer ei osaa havaita tekstityksiä jokaisella sivustolla. Voit aina ladata omia tekstitystiedostoja."
         },
         "videoSelect": {

--- a/common/locales/fi.json
+++ b/common/locales/fi.json
@@ -335,7 +335,8 @@
         "error": "Virhe: {{message}}",
         "errorNoMessage": "Virhe",
         "toggleSubtitlesShortcut": "Valitse tekstityksen näyttö painamalla \"{{keys}}\"",
-        "manualMiningIntervalPrompt": "Käytä louhintapikakuvaketta uudelleen"
+        "manualMiningIntervalPrompt": "Käytä louhintapikakuvaketta uudelleen",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Vedä ja pudota tekstitys ja media tiedostot, tai <1>browse</1>.",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Auto-detected subtitle tracks can be selected here. asbplayer does not know how to detect subtitles on every site. You can always load your own subtitle files."
         },
         "videoSelect": {

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -335,7 +335,8 @@
         "error": "Erreur : {{message}}",
         "errorNoMessage": "Erreur",
         "toggleSubtitlesShortcut": "Appuyez sur \"{{keys}}\" pour activer/désactiver l'affichage des sous-titres",
-        "manualMiningIntervalPrompt": "Réutiliser le raccourci de minage"
+        "manualMiningIntervalPrompt": "Réutiliser le raccourci de minage",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Glissez-déposez des fichiers de sous-titres et multimédia, ou <1>parcourir</1>.",

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Trek takarir yang terdeteksi otomatis dapat dipilih di sini. asbplayer tidak dapat mendeteksi takarir di semua situs. Anda selalu dapat memuat berkas takarir sendiri."
         },
         "videoSelect": {

--- a/common/locales/id.json
+++ b/common/locales/id.json
@@ -335,7 +335,8 @@
         "error": "Galat: {{message}}",
         "errorNoMessage": "Galat",
         "toggleSubtitlesShortcut": "Tekan \"{{keys}}\" untuk menampilkan/sembunyikan takarir",
-        "manualMiningIntervalPrompt": "Gunakan kembali pintasan penambangan"
+        "manualMiningIntervalPrompt": "Gunakan kembali pintasan penambangan",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Seret dan letakkan berkas takarir dan media, atau <1>jelajahi</1>.",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -335,7 +335,8 @@
         "error": "Errore: {{message}}",
         "errorNoMessage": "Errore",
         "toggleSubtitlesShortcut": "Premi \"{{keys}}\" per mostrare/nascondere i sottotitoli",
-        "manualMiningIntervalPrompt": "Usa di nuovo la scorciatoia di estrazione"
+        "manualMiningIntervalPrompt": "Usa di nuovo la scorciatoia di estrazione",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Trascina e rilascia file di sottotitoli e media, o <1>sfoglia</1>.",

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Qui è possibile selezionare le tracce dei sottotitoli rilevate automaticamente. asbplayer non sa come rilevare i sottotitoli su tutti i siti. Puoi sempre caricare i tuoi file di sottotitoli."
         },
         "videoSelect": {

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -335,7 +335,8 @@
         "error": "エラー：{{message}}",
         "errorNoMessage": "エラー",
         "toggleSubtitlesShortcut": "字幕を表示するには 「{{keys}}」 を押してください",
-        "manualMiningIntervalPrompt": "マイニングショートカットを再度使用してください"
+        "manualMiningIntervalPrompt": "マイニングショートカットを再度使用してください",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "字幕やメディアファイルをドラッグ＆ドロップ、または<1>ファイルを選択</1>してください。",

--- a/common/locales/ja.json
+++ b/common/locales/ja.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "自動検出された字幕トラックはここで選択できます。asbplayerはすべてのサイトで字幕トラックを検出できるわけではありません。自分の字幕ファイルはいつでもロードすることができます。"
         },
         "videoSelect": {

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -335,7 +335,8 @@
         "error": "오류: {{message}}",
         "errorNoMessage": "오류",
         "toggleSubtitlesShortcut": "\"{{keys}}\" 키를 눌러 자막 표시를 전환",
-        "manualMiningIntervalPrompt": "자막 추출 단축키를 다시 사용하세요"
+        "manualMiningIntervalPrompt": "자막 추출 단축키를 다시 사용하세요",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "자막 및 미디어 파일을 드래그 앤 드롭 하거나, <1>찾아보기</1>를 클릭하세요.",

--- a/common/locales/ko.json
+++ b/common/locales/ko.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "자동으로 감지된 자막 트랙은 여기에서 선택할 수 있습니다.\nasbplayer가 모든 사이트에서 자막을 감지할 수 있는 것은 아닙니다.\n언제든지 직접 자막 파일을 불러올 수 있습니다."
         },
         "videoSelect": {

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -335,7 +335,8 @@
         "error": "Błąd: {{message}}",
         "errorNoMessage": "Błąd",
         "toggleSubtitlesShortcut": "Naciśnij \"{{keys}}\", aby przełączyć wyświetlanie napisów",
-        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range"
+        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Przenieś i upuść napisy i pliki medialne, lub <1>przeglądaj</1>.",

--- a/common/locales/pl.json
+++ b/common/locales/pl.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Auto-detected subtitle tracks can be selected here. asbplayer does not know how to detect subtitles on every site. You can always load your own subtitle files."
         },
         "videoSelect": {

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "As faixas de legendas detectadas automaticamente podem ser selecionadas aqui. O asbplayer não sabe como detectar legendas em todo site. Você sempre pode carregar seus próprios arquivos de legenda."
         },
         "videoSelect": {

--- a/common/locales/pt_BR.json
+++ b/common/locales/pt_BR.json
@@ -335,7 +335,8 @@
         "error": "Erro: {{message}}",
         "errorNoMessage": "Erro",
         "toggleSubtitlesShortcut": "Press \"{{keys}}\" to toggle subtitle display",
-        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range"
+        "manualMiningIntervalPrompt": "Use mining shortcut again to select time range",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Arraste e solte arquivos de mídia e legenda, ou <1>procure</1>.",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "Здесь можно выбрать дорожки субтитров найденные автоматически. Автоматическая загрузка субтитров не работает на каждом сайте - вы всегда можете загрузить свои собственные файлы с субтитрами."
         },
         "videoSelect": {

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -335,7 +335,8 @@
         "error": "Ошибка: {{message}}",
         "errorNoMessage": "Ошибка",
         "toggleSubtitlesShortcut": "Нажмите \"{{keys}}\" для переключения отображения субтитров",
-        "manualMiningIntervalPrompt": "Нажмите горячую клавишу для майнинга ещё раз, чтобы задать временной отрезок"
+        "manualMiningIntervalPrompt": "Нажмите горячую клавишу для майнинга ещё раз, чтобы задать временной отрезок",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "Перетащите медиафайлы и файлы субтитров или <1>выберите</1> их.",

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -262,7 +262,7 @@
             "genericPage": "Use generic subtitle detection for this site",
             "aggressiveGenericPage": "Try aggressive detection methods (may degrade this site)",
             "genericPageInfo": "This page does not have a dedicated subtitle detection parser. Enable generic subtitle detection then refresh the page to possibly detect subtitles.",
-            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be selected on the site and the page refreshed to be usable.",
+            "genericPageWarning": "This site is using generic subtitle detection. Some subtitle tracks may be missing, mislabeled, incorrect, or inconsistently present between page loads. Additionally, a subtitle may need to be first selected on the site and shown on the video to be usable.",
             "ftue": "可在此选择自动检测到的字幕轨道。若未能识别，您可随时手动加载字幕文件。"
         },
         "videoSelect": {

--- a/common/locales/zh_CN.json
+++ b/common/locales/zh_CN.json
@@ -335,7 +335,8 @@
         "error": "错误：{{message}}",
         "errorNoMessage": "发生错误",
         "toggleSubtitlesShortcut": "按“{{keys}}”切换字幕显示",
-        "manualMiningIntervalPrompt": "再次使用挖掘快捷键确认时间段"
+        "manualMiningIntervalPrompt": "再次使用挖掘快捷键确认时间段",
+        "refreshForChangesToTakeEffect": "Refresh for changes to take effect"
     },
     "landing": {
         "cta": "拖放字幕与媒体文件至此，或点击 <1>浏览</1>。",

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -210,6 +210,7 @@ export interface VideoDataSubtitleTrackDef {
     url?: string | string[];
     file?: File;
     extension: string;
+    capturedDuringPlayback?: boolean;
 }
 
 export interface VideoDataSubtitleTrack extends VideoDataSubtitleTrackDef {

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -29,7 +29,9 @@ sidebar_position: 7
 ### Streaming services and subtitle detection
 
 :::tip
-For streaming services not listed below, asbplayer can attempt a best-effort generic subtitle detection which works for some websites.
+For streaming services not listed below, asbplayer can attempt a best-effort generic subtitle detection which works for ~85% of websites.
+
+You can always request a dedicated parser for any website, even if the generic parser detects subtitles, through an [issue](https://github.com/asbplayer/asbplayer/issues) or submit your own implementation in a [PR](https://github.com/asbplayer/asbplayer/pulls) on GitHub.
 :::
 
 | Service                 |                                                                                      Compatibility                                                                                       |
@@ -55,3 +57,4 @@ For streaming services not listed below, asbplayer can attempt a best-effort gen
 | Natural Japanese        |                                                                                            ✓                                                                                             |
 | SVT Play                |                                                                                            ✓                                                                                             |
 | UR Play                 |                                                                                            ✓                                                                                             |
+| All Other Websites      |                                                                Best-effort generic subtitle detection with ~85% efficacy.                                                                |

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -89,7 +89,7 @@ export default function Home(): ReactNode {
                         <p>
                             Add text-selectable subtitles to almost all video sources, including streaming video. Bring
                             your own subtitles, use auto-detected subtitles on 20+ supported websites, or try
-                            best-effort generic subtitle detection on other sites.
+                            best-effort generic subtitle detection which works on ~85% of websites.
                         </p>
                     </div>
                     <div className="col col--5">

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -375,7 +375,7 @@ export default class VideoDataSyncController {
         const wasLoading = this._syncedData?.subtitles === undefined;
         this._syncedData = data;
 
-        if (this.pickerVisible && !wasLoading) {
+        if (this.pickerVisible && !wasLoading && (await currentPageDelegate()).config.refreshSubtitleDataOnPickerOpen) {
             const subtitleIds = data.subtitles?.map((track) => track.id);
             if (!arrayEquals(previousSubtitleIds, subtitleIds)) {
                 this._frame.clientIfLoaded?.updateState({

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -93,6 +93,7 @@ export default class VideoDataSyncController {
     private _fullscreenElement?: Element;
     private _activeElement?: Element;
     private _autoSyncAttempted: boolean = false;
+    private _refreshingOpenPicker: boolean = false;
     private _dataReceivedListener?: (event: Event) => void;
     private _dataReceivedEventTarget?: EventTarget;
     private _isTutorial: boolean;
@@ -134,6 +135,7 @@ export default class VideoDataSyncController {
         this._dataReceivedListener = undefined;
         this._dataReceivedEventTarget = undefined;
         this._syncedData = undefined;
+        this._refreshingOpenPicker = false;
         this._cleanupPlayBlocker();
         this._openedLocation = undefined;
     }
@@ -191,9 +193,12 @@ export default class VideoDataSyncController {
             return;
         }
 
-        if (!refreshOpenPicker) {
+        if (refreshOpenPicker) {
+            this._refreshingOpenPicker = true;
+        } else {
             this._syncedData = undefined;
             this._autoSyncAttempted = false;
+            this._refreshingOpenPicker = false;
         }
 
         const eventTarget = pageDelegate.config.generic ? this._context.video : document;
@@ -375,7 +380,7 @@ export default class VideoDataSyncController {
         const wasLoading = this._syncedData?.subtitles === undefined;
         this._syncedData = data;
 
-        if (this.pickerVisible && !wasLoading && (await currentPageDelegate()).config.refreshSubtitleDataOnPickerOpen) {
+        if (this._refreshingOpenPicker && this.pickerVisible && !wasLoading) {
             const subtitleIds = data.subtitles?.map((track) => track.id);
             if (!arrayEquals(previousSubtitleIds, subtitleIds)) {
                 this._frame.clientIfLoaded?.updateState({
@@ -571,6 +576,7 @@ export default class VideoDataSyncController {
     private _hideAndResume() {
         this._cleanupPlayBlocker();
         this._openedLocation = undefined;
+        this._refreshingOpenPicker = false;
         this._context.keyBindings.bind(this._context);
         this._context.subtitleController.forceHideSubtitles = false;
         this._context.mobileVideoOverlayController.forceHide = false;

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -1,4 +1,4 @@
-import { asbError } from '@project/common/util';
+import { arrayEquals, asbError } from '@project/common/util';
 import type {
     ActiveProfileMessage,
     ConfirmedVideoDataSubtitleTrack,
@@ -60,6 +60,7 @@ interface ShowOptions {
 
 interface RequestSubtitlesOptions {
     readonly videoChanged: boolean;
+    readonly refreshOpenPicker?: boolean;
 }
 
 const fetchDataForLanguageOnDemand = (language: string): Promise<VideoData> => {
@@ -166,7 +167,7 @@ export default class VideoDataSyncController {
         return this._openedLocation;
     }
 
-    async requestSubtitles({ videoChanged }: RequestSubtitlesOptions) {
+    async requestSubtitles({ videoChanged, refreshOpenPicker = false }: RequestSubtitlesOptions) {
         if (!this._context.hasPageScript) {
             return;
         }
@@ -175,7 +176,7 @@ export default class VideoDataSyncController {
         // player events do not clobber an in-progress user selection. On a
         // true soft-navigation or an explicitly reported video change,
         // dismiss the stale picker and continue.
-        if (this.pickerVisible) {
+        if (this.pickerVisible && !refreshOpenPicker) {
             const locationChanged = this.openedLocation !== undefined && window.location.href !== this.openedLocation;
             if (locationChanged || videoChanged) {
                 this._hideAndResume();
@@ -190,8 +191,10 @@ export default class VideoDataSyncController {
             return;
         }
 
-        this._syncedData = undefined;
-        this._autoSyncAttempted = false;
+        if (!refreshOpenPicker) {
+            this._syncedData = undefined;
+            this._autoSyncAttempted = false;
+        }
 
         const eventTarget = pageDelegate.config.generic ? this._context.video : document;
         if (!this._dataReceivedListener || this._dataReceivedEventTarget !== eventTarget) {
@@ -242,6 +245,11 @@ export default class VideoDataSyncController {
         const model = await this._buildModel(additionalFields);
         this._prepareShow();
         client.updateState(model);
+
+        const pageDelegate = await currentPageDelegate();
+        if (pageDelegate.config.refreshSubtitleDataOnPickerOpen === true) {
+            void this.requestSubtitles({ videoChanged: false, refreshOpenPicker: true });
+        }
     }
 
     private async _buildModel(additionalFields: Partial<VideoDataUiModel>) {
@@ -363,8 +371,22 @@ export default class VideoDataSyncController {
     }
 
     private async _setSyncedData(data: VideoData) {
+        const previousSubtitleIds = this._syncedData?.subtitles?.map((track) => track.id);
         const wasLoading = this._syncedData?.subtitles === undefined;
         this._syncedData = data;
+
+        if (this.pickerVisible && !wasLoading) {
+            const subtitleIds = data.subtitles?.map((track) => track.id);
+            if (!arrayEquals(previousSubtitleIds, subtitleIds)) {
+                this._frame.clientIfLoaded?.updateState({
+                    subtitles: data.subtitles ?? [],
+                    suggestedName: data.basename,
+                    error: data.error ?? '',
+                    isLoading: false,
+                });
+            }
+            return;
+        }
 
         if (this._syncedData?.subtitles !== undefined && (await this._canAutoSync())) {
             if (!this._autoSyncAttempted) {

--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -58,10 +58,9 @@ interface ShowOptions {
     fromAsbplayerId?: string;
 }
 
-interface RequestSubtitlesOptions {
-    readonly videoChanged: boolean;
-    readonly refreshOpenPicker?: boolean;
-}
+type RequestSubtitlesOptions =
+    | { readonly kind: 'reload'; readonly videoChanged: boolean }
+    | { readonly kind: 'refresh-open-picker' };
 
 const fetchDataForLanguageOnDemand = (language: string): Promise<VideoData> => {
     return new Promise((resolve) => {
@@ -169,18 +168,18 @@ export default class VideoDataSyncController {
         return this._openedLocation;
     }
 
-    async requestSubtitles({ videoChanged, refreshOpenPicker = false }: RequestSubtitlesOptions) {
+    async requestSubtitles(request: RequestSubtitlesOptions) {
         if (!this._context.hasPageScript) {
             return;
         }
 
-        // While the picker is open on the same location, skip refresh so
-        // player events do not clobber an in-progress user selection. On a
-        // true soft-navigation or an explicitly reported video change,
-        // dismiss the stale picker and continue.
-        if (this.pickerVisible && !refreshOpenPicker) {
+        // While the picker is open on the same location, ignore ordinary reloads
+        // so player events do not clobber an in-progress user selection. On a true
+        // soft-navigation or an explicitly reported video change, dismiss the stale
+        // picker and continue.
+        if (this.pickerVisible && request.kind === 'reload') {
             const locationChanged = this.openedLocation !== undefined && window.location.href !== this.openedLocation;
-            if (locationChanged || videoChanged) {
+            if (locationChanged || request.videoChanged) {
                 this._hideAndResume();
             } else {
                 return;
@@ -193,7 +192,7 @@ export default class VideoDataSyncController {
             return;
         }
 
-        if (refreshOpenPicker) {
+        if (request.kind === 'refresh-open-picker') {
             this._refreshingOpenPicker = true;
         } else {
             this._syncedData = undefined;
@@ -253,7 +252,7 @@ export default class VideoDataSyncController {
 
         const pageDelegate = await currentPageDelegate();
         if (pageDelegate.config.refreshSubtitleDataOnPickerOpen === true) {
-            void this.requestSubtitles({ videoChanged: false, refreshOpenPicker: true });
+            void this.requestSubtitles({ kind: 'refresh-open-picker' });
         }
     }
 
@@ -376,45 +375,64 @@ export default class VideoDataSyncController {
     }
 
     private async _setSyncedData(data: VideoData) {
-        const previousSubtitleIds = this._syncedData?.subtitles?.map((track) => track.id);
-        const wasLoading = this._syncedData?.subtitles === undefined;
+        const previousData = this._syncedData;
         this._syncedData = data;
 
-        if (this._refreshingOpenPicker && this.pickerVisible && !wasLoading) {
-            const subtitleIds = data.subtitles?.map((track) => track.id);
-            if (!arrayEquals(previousSubtitleIds, subtitleIds)) {
-                this._frame.clientIfLoaded?.updateState({
-                    subtitles: data.subtitles ?? [],
-                    suggestedName: data.basename,
-                    error: data.error ?? '',
-                    isLoading: false,
-                });
-            }
-            return;
+        if (this._updateOpenPickerFromRefresh(previousData, data)) return;
+
+        const wasLoading = previousData?.subtitles === undefined;
+        if (await this._handleAutoSync(wasLoading)) return;
+
+        await this._updatePickerAfterDataReceived(wasLoading);
+    }
+
+    private _updateOpenPickerFromRefresh(previousData: VideoData | undefined, data: VideoData): boolean {
+        if (!this._refreshingOpenPicker || !this.pickerVisible || previousData?.subtitles === undefined) {
+            return false;
         }
 
-        if (this._syncedData?.subtitles !== undefined && (await this._canAutoSync())) {
-            if (!this._autoSyncAttempted) {
-                this._autoSyncAttempted = true;
-                const subs = this._matchLastSyncedWithAvailableTracks();
-
-                if (subs.completeMatch && !this.pickerVisible) {
-                    const autoSelectedTracks: VideoDataSubtitleTrack[] = subs.autoSelectedTracks;
-                    await this._syncData(autoSelectedTracks);
-                } else if (!subs.completeMatch && !this.pickerVisible) {
-                    const shouldPrompt = await this._settings.getSingle('streamingAutoSyncPromptOnFailure');
-
-                    if (shouldPrompt) {
-                        await this.show({ reason: VideoDataUiOpenReason.failedToAutoLoadPreferredTrack });
-                    }
-                } else if (wasLoading) {
-                    // Picker is open in loading state. Populate it now that tracks have arrived.
-                    this._frame.clientIfLoaded?.updateState(await this._buildModel({}));
-                }
-            }
-        } else if (!this.pickerVisible || wasLoading) {
-            this._frame.clientIfLoaded?.updateState(await this._buildModel({}));
+        const previousSubtitleIds = previousData.subtitles.map((track) => track.id);
+        const subtitleIds = data.subtitles?.map((track) => track.id);
+        if (!arrayEquals(previousSubtitleIds, subtitleIds)) {
+            this._frame.clientIfLoaded?.updateState({
+                subtitles: data.subtitles ?? [],
+                suggestedName: data.basename,
+                error: data.error ?? '',
+                isLoading: false,
+            });
         }
+
+        return true;
+    }
+
+    private async _handleAutoSync(wasLoading: boolean): Promise<boolean> {
+        if (this._syncedData?.subtitles === undefined || !(await this._canAutoSync())) return false;
+        if (this._autoSyncAttempted) return true;
+        this._autoSyncAttempted = true;
+
+        if (this.pickerVisible) {
+            if (wasLoading) this._frame.clientIfLoaded?.updateState(await this._buildModel({})); // Picker is open in loading state. Populate it now that tracks have arrived.
+            return true;
+        }
+
+        const subs = this._matchLastSyncedWithAvailableTracks();
+        if (subs.completeMatch) {
+            const autoSelectedTracks: VideoDataSubtitleTrack[] = subs.autoSelectedTracks;
+            await this._syncData(autoSelectedTracks);
+        } else {
+            const shouldPrompt = await this._settings.getSingle('streamingAutoSyncPromptOnFailure');
+
+            if (shouldPrompt) {
+                await this.show({ reason: VideoDataUiOpenReason.failedToAutoLoadPreferredTrack });
+            }
+        }
+
+        return true;
+    }
+
+    private async _updatePickerAfterDataReceived(wasLoading: boolean) {
+        if (this.pickerVisible && !wasLoading) return;
+        this._frame.clientIfLoaded?.updateState(await this._buildModel({}));
     }
 
     private async _canAutoSync(): Promise<boolean> {

--- a/extension/src/pages/aggressive-generic-page.test.ts
+++ b/extension/src/pages/aggressive-generic-page.test.ts
@@ -12,6 +12,19 @@ afterEach(() => {
     history.replaceState(null, '', '/');
 });
 
+function jsonResponse(url: string, value: unknown) {
+    return {
+        ok: true,
+        status: 200,
+        url,
+        headers: { get: () => 'application/json' },
+        clone() {
+            return this;
+        },
+        text: async () => JSON.stringify(value),
+    } as unknown as Response;
+}
+
 it('discovers contextual subtitle metadata observed through JSON.parse', async () => {
     const video = document.createElement('video');
     document.body.append(video);
@@ -49,6 +62,72 @@ it('discovers contextual subtitle metadata observed through JSON.parse', async (
     expect(JSON.parse).toBe(originalParse);
 });
 
+it('follows a subtitle metadata reference once and applies response URL context', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const metadataUrl = 'https://example.com/api/videos/1.json';
+    const subtitlesUrl = 'https://example.com/api/videos/1/subtitulos';
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url === metadataUrl) return jsonResponse(url, { video: { subtitleRef: subtitlesUrl } });
+        return jsonResponse(url, { page: { items: [{ src: '/captions/es.vtt', lang: 'es' }] } });
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch(metadataUrl);
+
+        const expected = {
+            subtitles: [
+                {
+                    label: 'es',
+                    language: 'es',
+                    url: 'https://example.com/captions/es.vtt',
+                    extension: 'vtt',
+                },
+            ],
+        };
+        await expect(discovery.videoData(video)).resolves.toMatchObject(expected);
+        await expect(discovery.videoData(video)).resolves.toMatchObject(expected);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('bounds subtitle metadata reference requests', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const metadataUrl = 'https://example.com/api/videos/1.json';
+    const references = Array.from({ length: 5 }, (_, index) => ({
+        subtitleRef: `https://example.com/api/subtitles/${index}`,
+    }));
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        return jsonResponse(url, url === metadataUrl ? { references } : { page: { items: [] } });
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch(metadataUrl);
+        await discovery.videoData(video);
+
+        expect(fetchMock).toHaveBeenCalledTimes(5);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
 it('sniffs extensionless subtitle responses intercepted through fetch', async () => {
     const video = document.createElement('video');
     document.body.append(video);
@@ -80,6 +159,63 @@ it('sniffs extensionless subtitle responses intercepted through fetch', async ()
                 }),
             ])
         );
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('fetches and sniffs an extensionless source identified by sibling subtitle metadata', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const metadataUrl = 'https://example.com/playback.json';
+    const subtitleUrl = 'https://cdn.example/subtitles/opaque-id';
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url === metadataUrl) {
+            return jsonResponse(url, {
+                subtitles: [
+                    {
+                        product_subtitle_language_id: 3,
+                        name: 'English',
+                        language: 'en',
+                        url: subtitleUrl,
+                    },
+                    { url: 'https://cdn.example/subtitles/insufficient-evidence' },
+                ],
+            });
+        }
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'text/plain' },
+            body: null,
+            text: async () => '\uFEFF1\n00:00:00,000 --> 00:00:01,000\nHello\n',
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch(metadataUrl);
+
+        const expected = {
+            subtitles: [
+                {
+                    label: 'English',
+                    language: 'en',
+                    url: subtitleUrl,
+                    extension: 'srt',
+                },
+            ],
+        };
+        await expect(discovery.videoData(video)).resolves.toMatchObject(expected);
+        await expect(discovery.videoData(video)).resolves.toMatchObject(expected);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
         uninstall();
         if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;

--- a/extension/src/pages/aggressive-generic-page.test.ts
+++ b/extension/src/pages/aggressive-generic-page.test.ts
@@ -1,9 +1,45 @@
 import { afterEach, expect, it, jest } from '@jest/globals';
 
-// This suite does not exercise TextTrack serialization, and its ESM dependency is not transformed by Jest.
-jest.mock('@project/common/subtitle-reader/subtitles-to-srt', () => ({ subtitlesToSrt: jest.fn() }));
+// The package ships ESM that this repository's Jest setup does not transform.
+jest.mock('@project/common/subtitle-reader/subtitles-to-srt', () => ({
+    subtitlesToSrt: (subtitles: readonly { text: string }[]) => subtitles.map(({ text }) => text).join('\n'),
+}));
 
 import { AggressiveGenericPageDiscovery } from '@project/extension/src/pages/aggressive-generic-page';
+
+function appendJson(value: unknown) {
+    const script = document.createElement('script');
+    script.type = 'application/json';
+    script.textContent = JSON.stringify(value);
+    document.body.appendChild(script);
+}
+
+function mockTextTrack(video: HTMLVideoElement, initialCues: readonly object[]) {
+    let cues = initialCues;
+    const track = new EventTarget() as EventTarget & TextTrack;
+    Object.defineProperties(track, {
+        kind: { configurable: true, value: 'captions' },
+        label: { configurable: true, value: 'English' },
+        language: { configurable: true, value: 'en' },
+        mode: { configurable: true, writable: true, value: 'hidden' },
+        cues: {
+            configurable: true,
+            get: () => Object.assign({}, cues, { length: cues.length }),
+        },
+    });
+    const textTracks = new EventTarget() as EventTarget & TextTrackList;
+    Object.defineProperties(textTracks, {
+        0: { configurable: true, value: track },
+        length: { configurable: true, value: 1 },
+    });
+    Object.defineProperty(video, 'textTracks', { configurable: true, value: textTracks });
+    return {
+        track,
+        setCues(value: readonly object[]) {
+            cues = value;
+        },
+    };
+}
 
 afterEach(() => {
     jest.useRealTimers();
@@ -60,6 +96,292 @@ it('discovers contextual subtitle metadata observed through JSON.parse', async (
     expect(window.fetch).toBe(originalFetch);
     expect(window.XMLHttpRequest.prototype.open).toBe(originalOpen);
     expect(JSON.parse).toBe(originalParse);
+});
+
+it('discovers HLS renditions from a manifest URL observed only in a runtime JSON response', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const resources = new Map([
+        [
+            'https://cdn.example/config/playback.json',
+            {
+                contentType: 'application/json',
+                text: JSON.stringify({ playback: { manifestUrl: '../master.m3u8' } }),
+            },
+        ],
+        [
+            'https://cdn.example/master.m3u8',
+            {
+                contentType: 'application/vnd.apple.mpegurl',
+                responseUrl: 'https://media.example/redirected/master.m3u8',
+                text: '#EXTM3U\n#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",LANGUAGE="en",URI="en.m3u8"\n#EXT-X-STREAM-INF:BANDWIDTH=1,SUBTITLES="subs"\nvideo.m3u8',
+            },
+        ],
+        [
+            'https://media.example/redirected/en.m3u8',
+            {
+                contentType: 'application/vnd.apple.mpegurl',
+                text: '#EXTM3U\n#EXTINF:10,\nen-1.vtt\n#EXT-X-ENDLIST',
+            },
+        ],
+    ]);
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const resource = resources.get(url);
+        if (resource === undefined) throw new Error(`Unexpected URL: ${url}`);
+        return {
+            ok: true,
+            status: 200,
+            url: 'responseUrl' in resource ? resource.responseUrl : url,
+            headers: { get: () => resource.contentType },
+            clone() {
+                return this;
+            },
+            text: async () => resource.text,
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://cdn.example/config/playback.json');
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [
+                {
+                    label: 'English',
+                    language: 'en',
+                    url: ['https://media.example/redirected/en-1.vtt'],
+                    extension: 'vtt',
+                },
+            ],
+        });
+        expect(fetchMock.mock.calls.map(([input]) => input.toString())).toEqual([
+            'https://cdn.example/config/playback.json',
+            'https://cdn.example/master.m3u8',
+            'https://media.example/redirected/en.m3u8',
+        ]);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('bounds manifest requests sourced from runtime JSON', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'application/vnd.apple.mpegurl' },
+            text: async () => '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nvideo.m3u8',
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        JSON.parse(
+            JSON.stringify({
+                playback: Array.from({ length: 4 }, (_, index) => ({
+                    manifestUrl: `https://cdn.example/master-${index}.m3u8`,
+                })),
+            })
+        );
+
+        await discovery.videoData(video);
+        expect(fetchMock.mock.calls.map(([input]) => input.toString())).toEqual([
+            'https://cdn.example/master-0.m3u8',
+            'https://cdn.example/master-1.m3u8',
+            'https://cdn.example/master-2.m3u8',
+        ]);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('uses a larger bounded traversal only for strongly hinted JSON.parse payloads', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        JSON.parse(
+            JSON.stringify({
+                blockers: Array.from({ length: 700 }, (_, index) => ({ analytics: index })),
+                player: {
+                    state: {
+                        subtitleInfos: [
+                            {
+                                Url: 'https://cdn.example/timedtext?id=1',
+                                Format: 'webvtt',
+                                LanguageCodeName: 'eng-US',
+                            },
+                        ],
+                    },
+                },
+            })
+        );
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [
+                {
+                    language: 'eng-us',
+                    url: 'https://cdn.example/timedtext?id=1',
+                    extension: 'vtt',
+                },
+            ],
+        });
+    } finally {
+        uninstall();
+    }
+});
+
+it('uses one bounded aggressive pass for a large late hydration payload', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    for (let index = 0; index < 7; index++) appendJson({ analytics: { index } });
+    appendJson({
+        padding: 'x'.repeat(130_000),
+        blockers: Array.from({ length: 700 }, (_, index) => ({ analytics: index })),
+        __DEFAULT_SCOPE__: {
+            webapp: {
+                videoDetail: {
+                    itemInfo: {
+                        itemStruct: {
+                            video: {
+                                subtitleInfos: [
+                                    {
+                                        Url: 'https://cdn.example/timedtext?id=1',
+                                        Format: 'webvtt',
+                                        LanguageCodeName: 'eng-US',
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [
+                {
+                    label: 'eng-us',
+                    language: 'eng-us',
+                    url: 'https://cdn.example/timedtext?id=1',
+                    extension: 'vtt',
+                },
+            ],
+        });
+    } finally {
+        uninstall();
+    }
+});
+
+it('passively accumulates enabled cues only in aggressive mode', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const firstCue = { startTime: 1, endTime: 2, text: 'First' };
+    const secondCue = { startTime: 3, endTime: 4, text: 'Second' };
+    const textTrack = mockTextTrack(video, [firstCue]);
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await discovery.videoData(video);
+        textTrack.setCues([secondCue]);
+        textTrack.track.dispatchEvent(new Event('cuechange'));
+        textTrack.setCues([]);
+
+        const data = await discovery.videoData(video);
+        expect(data.subtitles).toHaveLength(1);
+        expect(data.subtitles?.[0]).toMatchObject({
+            label: 'English (captured during playback)',
+            language: 'en',
+            extension: 'srt',
+        });
+        const text = decodeURIComponent((data.subtitles?.[0].url as string).split(',', 2)[1]);
+        expect(text).toContain('First');
+        expect(text).toContain('Second');
+        expect(textTrack.track.mode).toBe('hidden');
+    } finally {
+        uninstall();
+    }
+});
+
+it('clears aggressively accumulated cues on navigation and teardown', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const textTrack = mockTextTrack(video, [{ startTime: 1, endTime: 2, text: 'Old page' }]);
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    await discovery.videoData(video);
+    textTrack.setCues([]);
+    history.pushState(null, '', '/new-page');
+    await expect(discovery.videoData(video)).resolves.toMatchObject({ subtitles: [] });
+
+    textTrack.setCues([{ startTime: 3, endTime: 4, text: 'After cleanup' }]);
+    textTrack.track.dispatchEvent(new Event('cuechange'));
+    uninstall();
+    textTrack.setCues([]);
+    await expect(discovery.videoData(video)).resolves.toMatchObject({ subtitles: [] });
+});
+
+it('uses subtitle-service hostnames as context without matching unrelated prefixes', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'text/plain' },
+            clone() {
+                return this;
+            },
+            text: async () => 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n',
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://subscription.example/resource');
+        await window.fetch('https://subs.example/resource');
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [
+                expect.objectContaining({
+                    url: 'https://subs.example/resource',
+                    extension: 'vtt',
+                }),
+            ],
+        });
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
 });
 
 it('follows a subtitle metadata reference once and applies response URL context', async () => {
@@ -159,6 +481,207 @@ it('sniffs extensionless subtitle responses intercepted through fetch', async ()
                 }),
             ])
         );
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('trusts captured body structure over misleading subtitle URLs and MIME types', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const originalGetEntriesByType = Object.getOwnPropertyDescriptor(performance, 'getEntriesByType');
+    const responses = new Map([
+        ['https://cdn.example/empty.vtt', { contentType: 'text/vtt', text: '' }],
+        ['https://cdn.example/error.vtt', { contentType: 'text/vtt', text: '<!doctype html><title>Error</title>' }],
+        ['https://cdn.example/encrypted.vtt', { contentType: 'text/vtt', text: 'A'.repeat(128) }],
+        [
+            'https://cdn.example/captions.webvtt',
+            {
+                contentType: 'text/vtt',
+                text: JSON.stringify({ subtitles: [{ src: '/real.vtt', language: 'en' }] }),
+            },
+        ],
+    ]);
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const resource = responses.get(url);
+        if (resource === undefined) throw new Error(`Unexpected URL: ${url}`);
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => resource.contentType },
+            clone() {
+                return this;
+            },
+            text: async () => resource.text,
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    Object.defineProperty(performance, 'getEntriesByType', {
+        configurable: true,
+        value: () =>
+            Array.from(responses.keys(), (name) => ({
+                name,
+                entryType: 'resource',
+                initiatorType: 'fetch',
+            })) as PerformanceResourceTiming[],
+    });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        for (const url of responses.keys()) await window.fetch(url);
+
+        const data = await discovery.videoData(video);
+        expect(data.subtitles).toEqual([
+            expect.objectContaining({
+                language: 'en',
+                url: 'https://cdn.example/real.vtt',
+                extension: 'vtt',
+            }),
+        ]);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+        if (originalGetEntriesByType === undefined) Reflect.deleteProperty(performance, 'getEntriesByType');
+        else Object.defineProperty(performance, 'getEntriesByType', originalGetEntriesByType);
+    }
+});
+
+it('does not mistake a declared ASS subtitle with a late events section for JSON', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const url = 'https://cdn.example/long-styles.ass';
+    const text = `[Script Info]\n${'Comment: style metadata\n'.repeat(1_000)}[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello`;
+    Object.defineProperty(window, 'fetch', {
+        configurable: true,
+        writable: true,
+        value: jest.fn(async () => {
+            return {
+                ok: true,
+                status: 200,
+                url,
+                headers: { get: () => 'text/x-ass' },
+                clone() {
+                    return this;
+                },
+                text: async () => text,
+            } as unknown as Response;
+        }),
+    });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch(url);
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [expect.objectContaining({ url, extension: 'ass' })],
+        });
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('filters storyboard WebVTT without rejecting mixed dialogue cues', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const storyboard = `WEBVTT
+
+00:00:00.000 --> 00:00:01.000
+sprite.jpg#xywh=0,0,100,100
+
+00:00:01.000 --> 00:00:02.000
+sprite.jpg#xywh=100,0,100,100
+`;
+    const dialogue = `WEBVTT
+
+00:00:00.000 --> 00:00:01.000
+See image.jpg#xywh=0,0,100,100
+
+00:00:01.000 --> 00:00:02.000
+Spoken dialogue
+`;
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'text/vtt' },
+            clone() {
+                return this;
+            },
+            text: async () => (url.includes('storyboard') ? storyboard : dialogue),
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://cdn.example/storyboard.vtt');
+        await window.fetch('https://cdn.example/dialogue.vtt');
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [expect.objectContaining({ url: 'https://cdn.example/dialogue.vtt' })],
+        });
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('captures a MIME-mislabelled body only after metadata identifies its URL as a subtitle', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const identifiedUrl = 'https://media.example/resource?id=identified';
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'image/jpeg' },
+            clone() {
+                return this;
+            },
+            text: async () => 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n',
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://media.example/resource?id=unknown');
+        JSON.parse(
+            JSON.stringify({
+                captionTracks: [{ baseUrl: identifiedUrl, languageCodeName: 'en', fileName: 'English' }],
+            })
+        );
+        await window.fetch(identifiedUrl);
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({
+            subtitles: [
+                expect.objectContaining({
+                    label: 'English',
+                    language: 'en',
+                    url: identifiedUrl,
+                    extension: 'vtt',
+                }),
+            ],
+        });
     } finally {
         uninstall();
         if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
@@ -506,6 +1029,175 @@ it('discovers HLS renditions without also exposing their segments as tracks', as
     }
 });
 
+it('limits aggressive HLS discovery to ten subtitle renditions', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const renditions = Array.from({ length: 12 }, (_, index) => index);
+    const masterManifest = `#EXTM3U
+${renditions
+    .map(
+        (index) =>
+            `#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="Language ${index}",LANGUAGE="l${index}",URI="sub-${index}.m3u8"`
+    )
+    .join('\n')}
+#EXT-X-STREAM-INF:BANDWIDTH=1,SUBTITLES="subs"
+video.m3u8`;
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const match = /sub-(\d+)\.m3u8$/.exec(url);
+        const text =
+            url === 'https://cdn.example/master.m3u8'
+                ? masterManifest
+                : match === null
+                  ? undefined
+                  : `#EXTM3U\n#EXTINF:10,\nsub-${match[1]}.vtt\n#EXT-X-ENDLIST`;
+        if (text === undefined) throw new Error(`Unexpected URL: ${url}`);
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => 'application/vnd.apple.mpegurl' },
+            clone() {
+                return this;
+            },
+            text: async () => text,
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://cdn.example/master.m3u8');
+        const data = await discovery.videoData(video);
+
+        expect(data.subtitles).toHaveLength(10);
+        expect(fetchMock.mock.calls.map(([input]) => input.toString())).toEqual([
+            'https://cdn.example/master.m3u8',
+            ...renditions.slice(0, 10).map((index) => `https://cdn.example/sub-${index}.m3u8`),
+        ]);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('ranks a validated complete sidecar ahead of a segmented rendition', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const resources = new Map([
+        [
+            'https://cdn.example/master.m3u8',
+            {
+                contentType: 'application/vnd.apple.mpegurl',
+                text: '#EXTM3U\n#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",LANGUAGE="en",URI="en.m3u8"\n#EXT-X-STREAM-INF:BANDWIDTH=1,SUBTITLES="subs"\nvideo.m3u8',
+            },
+        ],
+        [
+            'https://cdn.example/en.m3u8',
+            {
+                contentType: 'application/vnd.apple.mpegurl',
+                text: '#EXTM3U\n#EXTINF:10,\nen-1.vtt\n#EXT-X-ENDLIST',
+            },
+        ],
+        [
+            'https://cdn.example/complete.srt',
+            {
+                contentType: 'application/x-subrip',
+                text: '1\n00:00:00,000 --> 00:00:01,000\nHello\n',
+            },
+        ],
+    ]);
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const resource = resources.get(url);
+        if (resource === undefined) throw new Error(`Unexpected URL: ${url}`);
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => resource.contentType },
+            clone() {
+                return this;
+            },
+            text: async () => resource.text,
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://cdn.example/master.m3u8');
+        await window.fetch('https://cdn.example/en.m3u8');
+        await window.fetch('https://cdn.example/complete.srt');
+
+        const data = await discovery.videoData(video);
+        expect(data.subtitles).toHaveLength(2);
+        expect(data.subtitles?.map((track) => track.url)).toEqual([
+            'https://cdn.example/complete.srt',
+            ['https://cdn.example/en-1.vtt'],
+        ]);
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('keeps HLS segment suppression after the parent manifest leaves the recent window', async () => {
+    let now = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const resources = new Map([
+        [
+            'https://cdn.example/master.m3u8',
+            '#EXTM3U\n#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",LANGUAGE="en",URI="en.m3u8"\n#EXT-X-STREAM-INF:BANDWIDTH=1,SUBTITLES="subs"\nvideo.m3u8',
+        ],
+        ['https://cdn.example/en.m3u8', '#EXTM3U\n#EXTINF:10,\nen-1.vtt\n#EXT-X-ENDLIST'],
+        ['https://cdn.example/en-1.vtt', 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n'],
+    ]);
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        const text = resources.get(url);
+        if (text === undefined) throw new Error(`Unexpected URL: ${url}`);
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => (url.endsWith('.m3u8') ? 'application/vnd.apple.mpegurl' : 'text/vtt') },
+            clone() {
+                return this;
+            },
+            text: async () => text,
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch('https://cdn.example/master.m3u8');
+        await window.fetch('https://cdn.example/en.m3u8');
+        await window.fetch('https://cdn.example/en-1.vtt');
+        await discovery.videoData(video);
+
+        now = 31_000;
+        await window.fetch('https://cdn.example/en-1.vtt');
+
+        await expect(discovery.videoData(video)).resolves.toMatchObject({ subtitles: [] });
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
 it('loads an HLS manifest discovered through buffered performance entries', async () => {
     const video = document.createElement('video');
     document.body.append(video);
@@ -604,6 +1296,56 @@ it('discovers extensionless DASH subtitles using representation MIME metadata', 
                     url: ['https://cdn.example/media/captions?id=en'],
                 },
             ],
+        });
+    } finally {
+        uninstall();
+        if (originalFetch === undefined) delete (window as { fetch?: typeof fetch }).fetch;
+        else window.fetch = originalFetch;
+    }
+});
+
+it('does not expose a DASH subtitle segment as a second standalone track', async () => {
+    const video = document.createElement('video');
+    document.body.append(video);
+    const originalFetch = window.fetch;
+    const manifestUrl = 'https://cdn.example/media/manifest.mpd';
+    const segmentUrl = 'https://cdn.example/media/captions.ttml';
+    const manifest = `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static" mediaPresentationDuration="PT10S">
+  <Period duration="PT10S">
+    <AdaptationSet contentType="text" mimeType="application/ttml+xml" lang="en">
+      <Representation id="sub-en"><BaseURL>captions.ttml</BaseURL></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`;
+    const ttml = '<tt xmlns="http://www.w3.org/ns/ttml"><body><p begin="0s" end="1s">Hello</p></body></tt>';
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        return {
+            ok: true,
+            status: 200,
+            url,
+            headers: { get: () => (url === manifestUrl ? 'application/dash+xml' : 'application/ttml+xml') },
+            clone() {
+                return this;
+            },
+            text: async () => (url === manifestUrl ? manifest : ttml),
+        } as unknown as Response;
+    });
+    Object.defineProperty(window, 'fetch', { configurable: true, writable: true, value: fetchMock });
+    const discovery = new AggressiveGenericPageDiscovery();
+    const uninstall = discovery.install();
+
+    try {
+        await window.fetch(manifestUrl);
+        await window.fetch(segmentUrl);
+
+        const data = await discovery.videoData(video);
+        expect(data.subtitles).toHaveLength(1);
+        expect(data.subtitles?.[0]).toMatchObject({
+            language: 'en',
+            url: [segmentUrl],
+            extension: 'ttml2',
         });
     } finally {
         uninstall();

--- a/extension/src/pages/aggressive-generic-page.test.ts
+++ b/extension/src/pages/aggressive-generic-page.test.ts
@@ -315,6 +315,7 @@ it('passively accumulates enabled cues only in aggressive mode', async () => {
             label: 'English (captured during playback)',
             language: 'en',
             extension: 'srt',
+            capturedDuringPlayback: true,
         });
         const text = decodeURIComponent((data.subtitles?.[0].url as string).split(',', 2)[1]);
         expect(text).toContain('First');

--- a/extension/src/pages/aggressive-generic-page.ts
+++ b/extension/src/pages/aggressive-generic-page.ts
@@ -1,5 +1,18 @@
 import type { VideoData, VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/common';
-import { BaseGenericPageDiscovery } from '@project/extension/src/pages/base-generic-page';
+import {
+    BaseGenericPageDiscovery,
+    capturedDuringPlaybackLabelSuffix,
+    cuesFromTextTrack,
+    maximumInlineJsonLength,
+    maximumInlineJsonScripts,
+    maximumTextTrackCues,
+    maximumTextTrackTextLength,
+} from '@project/extension/src/pages/base-generic-page';
+import type {
+    AccumulatedTextTrackCues,
+    SerializableCue,
+    TextTrackCueProvider,
+} from '@project/extension/src/pages/base-generic-page';
 import type {
     ExtensionlessSubtitleTrack,
     JsonDiscovery,
@@ -9,6 +22,8 @@ import {
     absoluteSubtitleUrl,
     bindVideoDataDiscovery,
     deduplicateTracks,
+    detectedSubtitleLabel,
+    hasSubtitleMetadataHint,
     isJsonContentType,
     normalizedContentType,
     responseTextWithinLimit,
@@ -16,10 +31,237 @@ import {
     subtitleExtensionsByContentType,
     tracksFromJson,
 } from '@project/extension/src/pages/subtitle-discovery';
-import { parseM3U8, subtitleTrackSegmentsFromM3U8Manifest } from '@project/extension/src/pages/m3u8-util';
+import {
+    limitM3U8SubtitleRenditions,
+    parseM3U8,
+    subtitleTrackSegmentsFromM3U8Manifest,
+} from '@project/extension/src/pages/m3u8-util';
 import type { MpdTrackMetadata, Playlist } from '@project/extension/src/pages/mpd-util';
 import { subtitleTracksFromMpdManifest } from '@project/extension/src/pages/mpd-util';
 import { extractExtension, trackFromDef } from '@project/extension/src/pages/util';
+
+const maximumTrackedVideos = 20;
+const maximumTrackedTextTracks = 50;
+const cueCaptureIntervalMs = 1_000;
+
+interface AccumulatedCue {
+    cue: SerializableCue;
+    globalKey: string;
+}
+
+interface TextTrackState {
+    id: number;
+    track: TextTrack;
+    cues: Map<string, AccumulatedCue>;
+    cueKeys: WeakMap<object, string>;
+    capturedOverTime: boolean;
+    initialized: boolean;
+    uninstall: () => void;
+}
+
+interface VideoTrackState {
+    tracks: Set<TextTrack>;
+    uninstall: () => void;
+    lastCaptureAt: number;
+}
+
+class AggressiveTextTrackCueAccumulator implements TextTrackCueProvider {
+    private readonly videos = new Map<HTMLVideoElement, VideoTrackState>();
+    private readonly tracks = new Map<TextTrack, TextTrackState>();
+    private readonly cueOrder = new Map<string, { state: TextTrackState; cueKey: string }>();
+    private page = window.location.href;
+    private nextTrackId = 0;
+    private totalCueTextLength = 0;
+    private installed = false;
+
+    install(eventTarget: Document = document) {
+        if (this.installed) return () => undefined;
+        this.installed = true;
+        const mediaListener = (event: Event) => {
+            if (!(event.target instanceof HTMLVideoElement)) return;
+            this.observeVideo(event.target);
+            this.captureVideo(event.target, event.type !== 'timeupdate');
+        };
+        for (const eventName of ['loadedmetadata', 'play', 'timeupdate']) {
+            eventTarget.addEventListener(eventName, mediaListener, true);
+        }
+        for (const video of Array.from(eventTarget.querySelectorAll('video'))) this.observeVideo(video);
+
+        return () => {
+            if (!this.installed) return;
+            this.installed = false;
+            for (const eventName of ['loadedmetadata', 'play', 'timeupdate']) {
+                eventTarget.removeEventListener(eventName, mediaListener, true);
+            }
+            for (const video of Array.from(this.videos.keys())) this.removeVideo(video);
+            this.clearCues();
+        };
+    }
+
+    cuesFor(video: HTMLVideoElement, track: TextTrack): AccumulatedTextTrackCues {
+        this.ensurePage();
+        if (this.installed) this.observeVideo(video);
+        const state = this.tracks.get(track);
+        if (state === undefined) {
+            return { cues: cuesFromTextTrack(track), capturedOverTime: false };
+        }
+        this.captureTrack(state);
+        return {
+            cues: Array.from(state.cues.values(), ({ cue }) => cue).sort(
+                (left, right) => left.startTime - right.startTime || left.endTime - right.endTime
+            ),
+            capturedOverTime: state.capturedOverTime,
+        };
+    }
+
+    private ensurePage() {
+        if (this.page === window.location.href) return;
+        this.page = window.location.href;
+        this.clearCues();
+    }
+
+    private observeVideo(video: HTMLVideoElement) {
+        this.ensurePage();
+        if (this.videos.has(video)) return;
+        while (this.videos.size >= maximumTrackedVideos) {
+            const oldest = this.videos.keys().next().value;
+            if (oldest === undefined) break;
+            this.removeVideo(oldest);
+        }
+
+        let textTracks: TextTrackList;
+        try {
+            textTracks = video.textTracks;
+        } catch {
+            return;
+        }
+        const state: VideoTrackState = {
+            tracks: new Set(),
+            lastCaptureAt: 0,
+            uninstall: () => undefined,
+        };
+        const addTrackListener = (event: Event) => {
+            const track = (event as TrackEvent).track;
+            if (track !== null) this.observeTrack(state, track);
+        };
+        if (typeof textTracks.addEventListener === 'function') {
+            textTracks.addEventListener('addtrack', addTrackListener);
+            state.uninstall = () => textTracks.removeEventListener('addtrack', addTrackListener);
+        }
+        this.videos.set(video, state);
+        try {
+            for (const track of Array.from(textTracks)) this.observeTrack(state, track);
+        } catch {
+            // Some player implementations expose non-iterable or unreadable track lists.
+        }
+    }
+
+    private observeTrack(videoState: VideoTrackState, track: TextTrack) {
+        if (videoState.tracks.has(track) || this.tracks.has(track)) return;
+        const kind = track.kind.toLowerCase();
+        if (kind !== 'subtitles' && kind !== 'captions') return;
+        if (this.tracks.size >= maximumTrackedTextTracks) return;
+
+        const state: TextTrackState = {
+            id: this.nextTrackId++,
+            track,
+            cues: new Map(),
+            cueKeys: new WeakMap(),
+            capturedOverTime: false,
+            initialized: false,
+            uninstall: () => undefined,
+        };
+        const cueListener = () => this.captureTrack(state);
+        if (typeof track.addEventListener === 'function') {
+            track.addEventListener('cuechange', cueListener);
+            state.uninstall = () => track.removeEventListener('cuechange', cueListener);
+        }
+        videoState.tracks.add(track);
+        this.tracks.set(track, state);
+        this.captureTrack(state);
+    }
+
+    private captureVideo(video: HTMLVideoElement, force: boolean) {
+        this.ensurePage();
+        const state = this.videos.get(video);
+        if (state === undefined) return;
+        const now = Date.now();
+        if (!force && now - state.lastCaptureAt < cueCaptureIntervalMs) return;
+        state.lastCaptureAt = now;
+        for (const track of state.tracks) {
+            const trackState = this.tracks.get(track);
+            if (trackState !== undefined) this.captureTrack(trackState);
+        }
+    }
+
+    private captureTrack(state: TextTrackState) {
+        const cues = cuesFromTextTrack(state.track);
+        let added = false;
+        for (const cue of cues) {
+            const cueKey = `${cue.startTime}\u0000${cue.endTime}\u0000${cue.text}`;
+            const cueObject = cue.source;
+            const previousKey = cueObject === undefined ? undefined : state.cueKeys.get(cueObject);
+            if (previousKey !== undefined && previousKey !== cueKey) this.removeCue(state, previousKey);
+            if (cueObject !== undefined) state.cueKeys.set(cueObject, cueKey);
+            if (state.cues.has(cueKey) || cue.text.length > maximumTextTrackTextLength) continue;
+
+            const globalKey = `${state.id}:${cueKey}`;
+            state.cues.set(cueKey, { cue, globalKey });
+            this.cueOrder.set(globalKey, { state, cueKey });
+            this.totalCueTextLength += cue.text.length;
+            added = true;
+            this.enforceBounds();
+        }
+        if (state.initialized && added) state.capturedOverTime = true;
+        state.initialized = true;
+    }
+
+    private enforceBounds() {
+        while (this.cueOrder.size > maximumTextTrackCues || this.totalCueTextLength > maximumTextTrackTextLength) {
+            const oldest = this.cueOrder.entries().next().value;
+            if (oldest === undefined) return;
+            const [globalKey, { state, cueKey }] = oldest;
+            this.cueOrder.delete(globalKey);
+            const accumulated = state.cues.get(cueKey);
+            if (accumulated === undefined) continue;
+            state.cues.delete(cueKey);
+            this.totalCueTextLength -= accumulated.cue.text.length;
+        }
+    }
+
+    private removeCue(state: TextTrackState, cueKey: string) {
+        const accumulated = state.cues.get(cueKey);
+        if (accumulated === undefined) return;
+        state.cues.delete(cueKey);
+        this.cueOrder.delete(accumulated.globalKey);
+        this.totalCueTextLength -= accumulated.cue.text.length;
+    }
+
+    private removeVideo(video: HTMLVideoElement) {
+        const videoState = this.videos.get(video);
+        if (videoState === undefined) return;
+        videoState.uninstall();
+        for (const track of videoState.tracks) {
+            const trackState = this.tracks.get(track);
+            if (trackState === undefined) continue;
+            trackState.uninstall();
+            for (const cueKey of Array.from(trackState.cues.keys())) this.removeCue(trackState, cueKey);
+            this.tracks.delete(track);
+        }
+        this.videos.delete(video);
+    }
+
+    private clearCues() {
+        this.cueOrder.clear();
+        this.totalCueTextLength = 0;
+        for (const state of this.tracks.values()) {
+            state.cues.clear();
+            state.cueKeys = new WeakMap();
+            state.capturedOverTime = false;
+            state.initialized = false;
+        }
+    }
+}
 
 type ResourceKind = 'hls' | 'dash' | 'subtitle' | 'json';
 
@@ -32,15 +274,37 @@ interface ResourceRecord {
     body?: Promise<string | undefined>;
 }
 
+interface TrackCandidate {
+    track: VideoDataSubtitleTrack;
+    score: number;
+    order: number;
+}
+
 const maximumCapturedBodyLength = 5_000_000;
 const maximumRecords = 100;
 const maximumJsonObjects = 500;
 const maximumJsonDepth = 12;
+const maximumHintedJsonLength = 512_000;
+const maximumHintedJsonObjects = 2_000;
 const maximumMetadataBodyLength = 1_000_000;
 const maximumMetadataReferences = 4;
+const maximumRuntimeJsonManifestUrls = 3;
+const maximumManifestSubtitleRenditions = 10;
+const maximumManifestChildUrls = 2_000;
 const responseObservationTimeoutMs = 500;
 const resourceFetchTimeoutMs = 3_000;
 const recentResourceWindowMs = 30_000;
+const trackCandidateScore = {
+    accumulatedTextTrack: 100,
+    unverifiedResource: 150,
+    inspectedResource: 200,
+    segmentedTrack: 300,
+    currentTextTrack: 325,
+    detectedResource: 340,
+    nativeTrack: 350,
+    metadataTrack: 400,
+    verifiedExtensionlessTrack: 500,
+} as const;
 const aggressiveJsonDiscoveryOptions = {
     contextual: true,
     maximumDepth: maximumJsonDepth,
@@ -55,7 +319,7 @@ function likelySubtitleUrl(url: string) {
     try {
         const parsed = new URL(url, document.baseURI);
         return /(?:caption|subtit|timedtext|texttrack|transcript|\bsubs?\b)/i.test(
-            `${parsed.pathname} ${parsed.searchParams.toString()}`
+            `${parsed.hostname} ${parsed.pathname} ${parsed.searchParams.toString()}`
         );
     } catch {
         return false;
@@ -64,6 +328,33 @@ function likelySubtitleUrl(url: string) {
 
 function jsonDiscoveryOptions(url: string) {
     return { ...aggressiveJsonDiscoveryOptions, rootSubtitleContext: likelySubtitleUrl(url) } as const;
+}
+
+function hintedInlineJson() {
+    let candidate: { text: string; priority: number } | undefined;
+    let jsonScriptIndex = 0;
+    for (const script of Array.from(document.querySelectorAll<HTMLScriptElement>('script[type]'))) {
+        const contentType = normalizedContentType(script.type);
+        if (contentType === undefined || contentType === 'application/ld+json' || !isJsonContentType(contentType)) {
+            continue;
+        }
+
+        const text = script.textContent?.trim();
+        if (!text) continue;
+        const priority = text.length > maximumInlineJsonLength || jsonScriptIndex >= maximumInlineJsonScripts ? 1 : 0;
+        jsonScriptIndex++;
+        if (
+            text.length > maximumHintedJsonLength ||
+            !hasSubtitleMetadataHint(text) ||
+            (candidate !== undefined &&
+                (candidate.priority > priority ||
+                    (candidate.priority === priority && candidate.text.length >= text.length)))
+        ) {
+            continue;
+        }
+        candidate = { text, priority };
+    }
+    return candidate?.text;
 }
 
 function subtitleExtensionFromText(text: string) {
@@ -82,10 +373,51 @@ function subtitleExtensionFromText(text: string) {
     return;
 }
 
+function isStoryboardVtt(text: string) {
+    const sample = text
+        .slice(0, 65_536)
+        .replace(/^\uFEFF/, '')
+        .trimStart();
+    if (!/^WEBVTT(?:\s|$)/i.test(sample)) return false;
+
+    const cueBlocks = sample.split(/\r?\n\s*\r?\n/).slice(1, 65);
+    let cues = 0;
+    let imageCues = 0;
+    for (const block of cueBlocks) {
+        const lines = block
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+        const timingLine = lines.findIndex((line) => line.includes('-->'));
+        if (timingLine < 0) continue;
+        const payload = lines.slice(timingLine + 1).join(' ');
+        if (!payload) continue;
+        cues++;
+        if (/(?:^|\s)(?:https?:\/\/|\.{0,2}\/)?\S+\.(?:avif|gif|jpe?g|png|webp)(?:\?\S*)?#xywh=/i.test(payload)) {
+            imageCues++;
+        }
+    }
+
+    return cues >= 2 && imageCues / cues >= 0.8;
+}
+
+function looksLikeJson(text: string) {
+    const sample = text.trimStart();
+    return sample.startsWith('{') || /^\[\s*(?:\]|[{"\d\-tfn])/.test(sample);
+}
+
+function looksLikeHtml(text: string) {
+    return /^(?:<!doctype\s+html\b|<html\b|<head\b|<body\b)/i.test(text.trimStart().slice(0, 16_384));
+}
+
+function looksLikeEncodedPayload(text: string) {
+    const compact = text.trim().replace(/\s+/g, '');
+    return compact.length >= 64 && /^[a-z\d+/]+={0,2}$/i.test(compact);
+}
+
 function kindFromResource(url: string, contentType?: string | null, text?: string): ResourceKind | undefined {
     const normalizedType = normalizedContentType(contentType);
     const extension = extractExtension(url, '').toLowerCase();
-    if (isJsonContentType(normalizedType)) return 'json';
     if (
         extension === 'm3u8' ||
         normalizedType === 'application/vnd.apple.mpegurl' ||
@@ -101,13 +433,18 @@ function kindFromResource(url: string, contentType?: string | null, text?: strin
     ) {
         return 'dash';
     }
+    if (text !== undefined) {
+        if (subtitleExtensionFromText(text) !== undefined) return 'subtitle';
+        if (looksLikeJson(text)) return 'json';
+    }
+    if (isJsonContentType(normalizedType)) return 'json';
     if (
         subtitleExtensionsByContentType[normalizedType ?? ''] !== undefined ||
         subtitleExtensionForUrl(url) !== undefined
     ) {
         return 'subtitle';
     }
-    return text !== undefined && subtitleExtensionFromText(text) !== undefined ? 'subtitle' : undefined;
+    return;
 }
 
 function requestUrl(input: RequestInfo | URL) {
@@ -134,7 +471,7 @@ function dashTrack(
         (metadata?.mimeType?.includes('ttml') === true ? 'ttml2' : undefined) ??
         (metadata?.mimeType?.includes('vtt') === true ? 'vtt' : undefined);
     if (extension === undefined) return;
-    return { label: language || 'Detected subtitle', language: language || undefined, url, extension };
+    return { label: language || detectedSubtitleLabel, language: language || undefined, url, extension };
 }
 
 function standaloneHlsTrack(manifestUrl: string, manifest: any): VideoDataSubtitleTrack | undefined {
@@ -150,25 +487,45 @@ function standaloneHlsTrack(manifestUrl: string, manifest: any): VideoDataSubtit
     );
     if (extensions.size !== 1) return;
     const extension: string | undefined = extensions.values().next().value;
-    return extension === undefined ? undefined : trackFromDef({ label: 'Detected subtitle', url: urls, extension });
+    return extension === undefined ? undefined : trackFromDef({ label: detectedSubtitleLabel, url: urls, extension });
+}
+
+function baseTrackScore(track: VideoDataSubtitleTrack) {
+    if (Array.isArray(track.url)) return trackCandidateScore.segmentedTrack;
+    if (track.label.endsWith(capturedDuringPlaybackLabelSuffix)) return trackCandidateScore.accumulatedTextTrack;
+    if (track.url?.startsWith('data:') === true) return trackCandidateScore.currentTextTrack;
+    return trackCandidateScore.nativeTrack;
+}
+
+function directResourceTrackScore(detectedExtension: string | undefined, text: string | undefined) {
+    if (detectedExtension !== undefined) return trackCandidateScore.detectedResource;
+    return text === undefined ? trackCandidateScore.unverifiedResource : trackCandidateScore.inspectedResource;
 }
 
 export class AggressiveGenericPageDiscovery implements VideoDataProvider {
-    private readonly baseDiscovery = new BaseGenericPageDiscovery();
+    private readonly cueAccumulator = new AggressiveTextTrackCueAccumulator();
+    private readonly baseDiscovery = new BaseGenericPageDiscovery(this.cueAccumulator);
     private readonly records: ResourceRecord[] = [];
     private readonly parsedJson: Array<{
         tracks: VideoDataSubtitleTrack[];
+        manifestUrls: string[];
         metadataUrls: string[];
         extensionlessTracks: ExtensionlessSubtitleTrack[];
         page: string;
         observedAt: number;
     }> = [];
     private readonly pending = new Set<Promise<unknown>>();
+    private readonly manifestChildUrls = new Set<string>();
+    private readonly rejectedResourceUrls = new Set<string>();
+    private statePage?: string;
     private originalFetch?: typeof window.fetch;
+    private originalJsonParse?: typeof JSON.parse;
+    private hintedInlineJson?: { page: string; discovery: JsonDiscovery };
 
     install(): () => void {
         const cleanup: Array<() => void> = [];
         let active = true;
+        cleanup.push(this.cueAccumulator.install());
         const originalFetch = window.fetch;
         this.originalFetch = originalFetch;
         const interceptedFetch: typeof window.fetch = (...args) => {
@@ -193,6 +550,7 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         const originalOpen = window.XMLHttpRequest.prototype.open;
         const observe = this.observe.bind(this);
         const rememberPending = this.rememberPending.bind(this);
+        const shouldObserveResource = this.shouldObserveResource.bind(this);
         const interceptedOpen = function (this: XMLHttpRequest, ...args: unknown[]) {
             const url = typeof args[1] === 'string' ? absoluteSubtitleUrl(args[1]) : undefined;
             if (url !== undefined) {
@@ -209,12 +567,7 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                             return;
                         }
                         const contentType = this.getResponseHeader('Content-Type');
-                        if (
-                            kindFromResource(request.url, contentType) === undefined &&
-                            !likelySubtitleUrl(request.url)
-                        ) {
-                            return;
-                        }
+                        if (!shouldObserveResource(request.url, contentType, request.page)) return;
                         let text: string | undefined;
                         try {
                             if (this.responseType === '' || this.responseType === 'text') text = this.responseText;
@@ -255,10 +608,13 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         });
 
         const originalParse = JSON.parse;
+        this.originalJsonParse = originalParse;
         const interceptedParse: typeof JSON.parse = (...args: Parameters<typeof JSON.parse>) => {
             const value = originalParse(...args);
             if (active && value !== null && typeof value === 'object') {
-                this.rememberJson(value, pageIdentity(), document.baseURI);
+                const text = args[0];
+                const hinted = text.length <= maximumHintedJsonLength && hasSubtitleMetadataHint(text);
+                this.rememberJson(value, pageIdentity(), document.baseURI, hinted);
             }
             return value;
         };
@@ -301,20 +657,40 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         await this.settlePending();
         const base = await this.baseDiscovery.videoData(video);
         const page = pageIdentity();
-        const tracks = [...(base.subtitles ?? [])];
+        this.preparePageState(page);
+        const candidates: TrackCandidate[] = [];
+        const addTracks = (tracks: readonly VideoDataSubtitleTrack[], score: number) => {
+            for (const track of tracks) candidates.push({ track, score, order: candidates.length });
+        };
+        for (const track of base.subtitles ?? []) {
+            candidates.push({ track, score: baseTrackScore(track), order: candidates.length });
+        }
         const metadataUrls = new Set<string>();
+        const runtimeJsonManifestUrls = new Set<string>();
         const extensionlessTracks = new Map<string, ExtensionlessSubtitleTrack>();
 
-        for (const snapshot of this.parsedJson.filter((snapshot) => snapshot.page === page)) {
-            tracks.push(...snapshot.tracks);
+        const inlineJson = this.discoveryFromHintedInlineJson(page);
+        if (inlineJson !== undefined) {
+            addTracks(inlineJson.tracks, trackCandidateScore.metadataTrack);
+            for (const url of inlineJson.manifestUrls) this.observe(url, page);
+            for (const url of inlineJson.metadataUrls) metadataUrls.add(url);
+            for (const track of inlineJson.extensionlessTracks) extensionlessTracks.set(track.url, track);
+        }
+
+        const pageJsonSnapshots = this.parsedJson.filter((snapshot) => snapshot.page === page);
+        for (const snapshot of pageJsonSnapshots) {
+            addTracks(snapshot.tracks, trackCandidateScore.metadataTrack);
             for (const url of snapshot.metadataUrls) metadataUrls.add(url);
             for (const track of snapshot.extensionlessTracks) extensionlessTracks.set(track.url, track);
+        }
+        for (let index = pageJsonSnapshots.length - 1; index >= 0; index--) {
+            for (const url of pageJsonSnapshots[index].manifestUrls) runtimeJsonManifestUrls.add(url);
         }
 
         const pageRecords = this.records.filter((record) => record.page === page);
         const newest = Math.max(...pageRecords.map((record) => record.observedAt), 0);
         const directRecords: Array<{ record: ResourceRecord; text?: string }> = [];
-        const hlsSegmentUrls = new Set<string>();
+        const processedHlsManifestUrls = new Set<string>();
         for (const record of pageRecords.filter((record) => newest - record.observedAt <= recentResourceWindowMs)) {
             let text: string | undefined;
             try {
@@ -326,10 +702,12 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
             }
             const kind = kindFromResource(record.url, record.contentType, text) ?? record.kind;
             if (kind === 'json' && text !== undefined) {
+                if (record.kind === 'subtitle') this.rememberRejectedResource(record.url);
                 try {
-                    const value = JSON.parse(text);
+                    const value = (this.originalJsonParse ?? JSON.parse)(text);
                     const discovery = tracksFromJson(value, record.url, jsonDiscoveryOptions(record.url));
-                    tracks.push(...discovery.tracks);
+                    addTracks(discovery.tracks, trackCandidateScore.metadataTrack);
+                    for (const url of discovery.manifestUrls) runtimeJsonManifestUrls.add(url);
                     for (const url of discovery.metadataUrls) metadataUrls.add(url);
                     for (const track of discovery.extensionlessTracks) extensionlessTracks.set(track.url, track);
                 } catch {
@@ -337,41 +715,27 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                 }
             } else if (kind === 'hls' && text !== undefined) {
                 try {
-                    const manifest = parseM3U8(text);
-                    const manifestTracks = await subtitleTrackSegmentsFromM3U8Manifest(
-                        record.url,
-                        manifest,
-                        async (url) => {
-                            const matching = pageRecords.find((candidate) => candidate.url === url);
-                            const subtitleText =
-                                matching === undefined ? await this.fetchText(url) : await this.resourceText(matching);
-                            if (subtitleText === undefined) throw new Error('Unable to load HLS subtitle manifest');
-                            const subtitleManifest = parseM3U8(subtitleText);
-                            for (const segment of subtitleManifest.segments ?? []) {
-                                if (typeof segment?.uri !== 'string') continue;
-                                const segmentUrl = absoluteSubtitleUrl(segment.uri, url);
-                                if (segmentUrl !== undefined) hlsSegmentUrls.add(segmentUrl);
-                            }
-                            return { manifest: subtitleManifest, url };
-                        }
+                    processedHlsManifestUrls.add(record.url);
+                    addTracks(
+                        await this.tracksFromHlsManifest(record.url, text, pageRecords),
+                        trackCandidateScore.segmentedTrack
                     );
-                    tracks.push(...manifestTracks);
-                    if (manifestTracks.length === 0) {
-                        const standaloneTrack = standaloneHlsTrack(record.url, manifest);
-                        if (standaloneTrack !== undefined) {
-                            tracks.push(standaloneTrack);
-                            const urls = Array.isArray(standaloneTrack.url)
-                                ? standaloneTrack.url
-                                : [standaloneTrack.url];
-                            for (const url of urls) if (url !== undefined) hlsSegmentUrls.add(url);
-                        }
-                    }
                 } catch {
                     // A speculative manifest should not prevent other candidates from being tried.
                 }
             } else if (kind === 'dash' && text !== undefined) {
                 try {
-                    tracks.push(...subtitleTracksFromMpdManifest(record.url, text, dashTrack));
+                    addTracks(
+                        subtitleTracksFromMpdManifest(record.url, text, (playlist, language, metadata) => {
+                            for (const segment of playlist.segments ?? []) {
+                                if (typeof segment.resolvedUri === 'string') {
+                                    this.rememberManifestChild(segment.resolvedUri);
+                                }
+                            }
+                            return dashTrack(playlist, language, metadata);
+                        }),
+                        trackCandidateScore.segmentedTrack
+                    );
                 } catch {
                     // Ignore malformed or unsupported DASH manifests.
                 }
@@ -390,12 +754,32 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                         ? await this.fetchText(url, maximumMetadataBodyLength)
                         : await this.resourceText(matching);
                 if (text === undefined) continue;
-                const value = JSON.parse(text);
+                const value = (this.originalJsonParse ?? JSON.parse)(text);
                 if (matching === undefined) this.observe(url, page, 'application/json', text);
                 const discovery = tracksFromJson(value, url, jsonDiscoveryOptions(url));
-                tracks.push(...discovery.tracks);
+                addTracks(discovery.tracks, trackCandidateScore.metadataTrack);
+                for (const manifestUrl of discovery.manifestUrls) runtimeJsonManifestUrls.add(manifestUrl);
             } catch {
                 // Ignore unavailable or malformed speculative subtitle metadata.
+            }
+        }
+
+        for (const url of Array.from(runtimeJsonManifestUrls).slice(0, maximumRuntimeJsonManifestUrls)) {
+            if (processedHlsManifestUrls.has(url)) continue;
+            try {
+                const matching = pageRecords.find((record) => record.url === url);
+                const resource =
+                    matching === undefined
+                        ? await this.fetchTextResource(url)
+                        : { text: await this.resourceText(matching), url: matching.url };
+                if (resource?.text !== undefined) {
+                    addTracks(
+                        await this.tracksFromHlsManifest(resource.url, resource.text, pageRecords),
+                        trackCandidateScore.segmentedTrack
+                    );
+                }
+            } catch {
+                // Ignore unavailable speculative manifests.
             }
         }
 
@@ -410,12 +794,19 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                         ? await this.fetchText(candidate.url, maximumMetadataBodyLength)
                         : await this.resourceText(matching);
                 if (text === undefined) continue;
+                if (!text.trim() || looksLikeHtml(text) || looksLikeEncodedPayload(text)) continue;
                 const extension =
-                    subtitleExtensionsByContentType[normalizedContentType(matching?.contentType) ?? ''] ??
-                    subtitleExtensionFromText(text);
-                if (extension !== undefined) {
+                    subtitleExtensionFromText(text) ??
+                    subtitleExtensionsByContentType[normalizedContentType(matching?.contentType) ?? ''];
+                if (extension !== undefined && !(extension === 'vtt' && isStoryboardVtt(text))) {
+                    this.rejectedResourceUrls.delete(candidate.url);
                     if (matching === undefined) this.observe(candidate.url, page, undefined, text);
-                    tracks.push(trackFromDef({ ...candidate, extension }));
+                    addTracks(
+                        [trackFromDef({ ...candidate, extension })],
+                        trackCandidateScore.verifiedExtensionlessTrack
+                    );
+                } else if (extension === 'vtt') {
+                    this.rememberRejectedResource(candidate.url);
                 }
             } catch {
                 // Ignore unavailable or unsupported speculative subtitle resources.
@@ -423,24 +814,85 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         }
 
         for (const { record, text } of directRecords) {
-            if (hlsSegmentUrls.has(record.url)) continue;
+            if (this.manifestChildUrls.has(record.url)) continue;
+            if (text !== undefined) {
+                if (!text.trim() || looksLikeHtml(text) || looksLikeEncodedPayload(text)) {
+                    this.rememberRejectedResource(record.url);
+                    continue;
+                }
+            }
+            const detectedExtension = text === undefined ? undefined : subtitleExtensionFromText(text);
+            if (detectedExtension === 'vtt' && text !== undefined && isStoryboardVtt(text)) {
+                this.rememberRejectedResource(record.url);
+                continue;
+            }
             const extension =
+                detectedExtension ??
                 subtitleExtensionsByContentType[normalizedContentType(record.contentType) ?? ''] ??
                 subtitleExtensionForUrl(record.url) ??
-                (text === undefined ? undefined : subtitleExtensionFromText(text));
+                undefined;
             if (extension !== undefined) {
-                tracks.push(trackFromDef({ label: 'Detected subtitle', url: record.url, extension }));
+                this.rejectedResourceUrls.delete(record.url);
+                addTracks(
+                    [trackFromDef({ label: detectedSubtitleLabel, url: record.url, extension })],
+                    directResourceTrackScore(detectedExtension, text)
+                );
             }
         }
 
-        return { error: '', basename: base.basename, subtitles: deduplicateTracks(tracks) };
+        const rankedTracks = candidates
+            .filter(({ track }) => {
+                if (Array.isArray(track.url)) return true;
+                return (
+                    track.url !== undefined &&
+                    !this.rejectedResourceUrls.has(track.url) &&
+                    !this.manifestChildUrls.has(track.url)
+                );
+            })
+            .sort((left, right) => right.score - left.score || left.order - right.order)
+            .map(({ track }) => track);
+        return { error: '', basename: base.basename, subtitles: deduplicateTracks(rankedTracks) };
+    }
+
+    private async tracksFromHlsManifest(
+        manifestUrl: string,
+        text: string,
+        pageRecords: readonly ResourceRecord[]
+    ): Promise<VideoDataSubtitleTrack[]> {
+        const manifest = limitM3U8SubtitleRenditions(parseM3U8(text), maximumManifestSubtitleRenditions);
+        const tracks = await subtitleTrackSegmentsFromM3U8Manifest(
+            manifestUrl,
+            manifest,
+            async (subtitleManifestUrl) => {
+                const matching = pageRecords.find((candidate) => candidate.url === subtitleManifestUrl);
+                const resource =
+                    matching === undefined
+                        ? await this.fetchTextResource(subtitleManifestUrl)
+                        : { text: await this.resourceText(matching), url: matching.url };
+                if (resource?.text === undefined) throw new Error('Unable to load HLS subtitle manifest');
+                const subtitleManifest = parseM3U8(resource.text);
+                for (const segment of subtitleManifest.segments ?? []) {
+                    if (typeof segment?.uri !== 'string') continue;
+                    const segmentUrl = absoluteSubtitleUrl(segment.uri, resource.url);
+                    if (segmentUrl !== undefined) this.rememberManifestChild(segmentUrl);
+                }
+                return { manifest: subtitleManifest, url: resource.url };
+            }
+        );
+        if (tracks.length > 0) return tracks;
+
+        const standaloneTrack = standaloneHlsTrack(manifestUrl, manifest);
+        if (standaloneTrack === undefined) return [];
+        const urls = Array.isArray(standaloneTrack.url) ? standaloneTrack.url : [standaloneTrack.url];
+        for (const url of urls) if (url !== undefined) this.rememberManifestChild(url);
+        return [standaloneTrack];
     }
 
     private observeResponse(response: Response, requestedUrl: string | undefined, page: string) {
         const url = response.url || requestedUrl;
         if (url === undefined || (!response.ok && response.status !== 304)) return;
         const contentType = response.headers.get('Content-Type') ?? undefined;
-        if (kindFromResource(url, contentType) === undefined && !likelySubtitleUrl(url)) return;
+        if (!this.shouldObserveResource(url, contentType, page)) return;
         const body = responseTextWithinLimit(response, maximumCapturedBodyLength, responseObservationTimeoutMs).catch(
             () => undefined
         );
@@ -448,7 +900,7 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         return body.then((text) => {
             if (text !== undefined && isJsonContentType(contentType)) {
                 try {
-                    this.rememberJson(JSON.parse(text), page, url);
+                    this.rememberJson((this.originalJsonParse ?? JSON.parse)(text), page, url);
                 } catch {
                     // Ignore malformed JSON responses.
                 }
@@ -484,14 +936,77 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         if (this.records.length > maximumRecords) this.records.splice(0, this.records.length - maximumRecords);
     }
 
-    private rememberJson(value: unknown, page: string, baseUrl: string) {
-        const discovery: JsonDiscovery = tracksFromJson(value, baseUrl, jsonDiscoveryOptions(baseUrl));
+    private rememberJson(value: unknown, page: string, baseUrl: string, hinted = false) {
+        const discovery: JsonDiscovery = tracksFromJson(value, baseUrl, {
+            ...jsonDiscoveryOptions(baseUrl),
+            maximumObjects: hinted ? maximumHintedJsonObjects : maximumJsonObjects,
+        });
         const tracks = deduplicateTracks(discovery.tracks);
+        const manifestUrls = Array.from(discovery.manifestUrls);
         const metadataUrls = Array.from(discovery.metadataUrls);
         const extensionlessTracks = discovery.extensionlessTracks;
-        if (tracks.length === 0 && metadataUrls.length === 0 && extensionlessTracks.length === 0) return;
-        this.parsedJson.push({ tracks, metadataUrls, extensionlessTracks, page, observedAt: Date.now() });
+        if (
+            tracks.length === 0 &&
+            manifestUrls.length === 0 &&
+            metadataUrls.length === 0 &&
+            extensionlessTracks.length === 0
+        ) {
+            return;
+        }
+        this.parsedJson.push({ tracks, manifestUrls, metadataUrls, extensionlessTracks, page, observedAt: Date.now() });
         if (this.parsedJson.length > 20) this.parsedJson.shift();
+    }
+
+    private discoveryFromHintedInlineJson(page: string) {
+        if (this.hintedInlineJson?.page === page) return this.hintedInlineJson.discovery;
+        const text = hintedInlineJson();
+        if (text === undefined) return;
+        try {
+            const discovery = tracksFromJson((this.originalJsonParse ?? JSON.parse)(text), document.baseURI, {
+                ...jsonDiscoveryOptions(document.baseURI),
+                maximumObjects: maximumHintedJsonObjects,
+            });
+            this.hintedInlineJson = { page, discovery };
+            return discovery;
+        } catch {
+            return;
+        }
+    }
+
+    private shouldObserveResource(url: string, contentType: string | null | undefined, page: string) {
+        if (kindFromResource(url, contentType) !== undefined || likelySubtitleUrl(url)) return true;
+        return this.parsedJson.some(
+            (snapshot) =>
+                snapshot.page === page &&
+                (snapshot.metadataUrls.includes(url) ||
+                    snapshot.extensionlessTracks.some((track) => track.url === url) ||
+                    snapshot.tracks.some((track) =>
+                        Array.isArray(track.url) ? track.url.includes(url) : track.url === url
+                    ))
+        );
+    }
+
+    private preparePageState(page: string) {
+        if (this.statePage === page) return;
+        this.statePage = page;
+        this.manifestChildUrls.clear();
+        this.rejectedResourceUrls.clear();
+    }
+
+    private rememberManifestChild(url: string) {
+        if (this.manifestChildUrls.has(url)) return;
+        this.manifestChildUrls.add(url);
+        if (this.manifestChildUrls.size <= maximumManifestChildUrls) return;
+        const oldest = this.manifestChildUrls.values().next().value;
+        if (oldest !== undefined) this.manifestChildUrls.delete(oldest);
+    }
+
+    private rememberRejectedResource(url: string) {
+        if (this.rejectedResourceUrls.has(url)) return;
+        this.rejectedResourceUrls.add(url);
+        if (this.rejectedResourceUrls.size <= maximumRecords) return;
+        const oldest = this.rejectedResourceUrls.values().next().value;
+        if (oldest !== undefined) this.rejectedResourceUrls.delete(oldest);
     }
 
     private rememberPending(promise: Promise<unknown>) {
@@ -513,6 +1028,10 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
     }
 
     private async fetchText(url: string, maximumLength = maximumCapturedBodyLength) {
+        return (await this.fetchTextResource(url, maximumLength))?.text;
+    }
+
+    private async fetchTextResource(url: string, maximumLength = maximumCapturedBodyLength) {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), resourceFetchTimeoutMs);
         try {
@@ -521,7 +1040,8 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                 signal: controller.signal,
             });
             if (!response.ok && response.status !== 304) return;
-            return await responseTextWithinLimit(response, maximumLength);
+            const text = await responseTextWithinLimit(response, maximumLength);
+            return text === undefined ? undefined : { text, url: response.url || url };
         } finally {
             clearTimeout(timeout);
         }

--- a/extension/src/pages/aggressive-generic-page.ts
+++ b/extension/src/pages/aggressive-generic-page.ts
@@ -1,7 +1,6 @@
 import type { VideoData, VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/common';
 import {
     BaseGenericPageDiscovery,
-    capturedDuringPlaybackLabelSuffix,
     cuesFromTextTrack,
     maximumInlineJsonLength,
     maximumInlineJsonScripts,
@@ -492,7 +491,7 @@ function standaloneHlsTrack(manifestUrl: string, manifest: any): VideoDataSubtit
 
 function baseTrackScore(track: VideoDataSubtitleTrack) {
     if (Array.isArray(track.url)) return trackCandidateScore.segmentedTrack;
-    if (track.label.endsWith(capturedDuringPlaybackLabelSuffix)) return trackCandidateScore.accumulatedTextTrack;
+    if (track.capturedDuringPlayback === true) return trackCandidateScore.accumulatedTextTrack;
     if (track.url?.startsWith('data:') === true) return trackCandidateScore.currentTextTrack;
     return trackCandidateScore.nativeTrack;
 }

--- a/extension/src/pages/aggressive-generic-page.ts
+++ b/extension/src/pages/aggressive-generic-page.ts
@@ -1,6 +1,10 @@
 import type { VideoData, VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/common';
 import { BaseGenericPageDiscovery } from '@project/extension/src/pages/base-generic-page';
-import type { VideoDataProvider } from '@project/extension/src/pages/subtitle-discovery';
+import type {
+    ExtensionlessSubtitleTrack,
+    JsonDiscovery,
+    VideoDataProvider,
+} from '@project/extension/src/pages/subtitle-discovery';
 import {
     absoluteSubtitleUrl,
     bindVideoDataDiscovery,
@@ -31,7 +35,9 @@ interface ResourceRecord {
 const maximumCapturedBodyLength = 5_000_000;
 const maximumRecords = 100;
 const maximumJsonObjects = 500;
-const maximumJsonDepth = 6;
+const maximumJsonDepth = 12;
+const maximumMetadataBodyLength = 1_000_000;
+const maximumMetadataReferences = 4;
 const responseObservationTimeoutMs = 500;
 const resourceFetchTimeoutMs = 3_000;
 const recentResourceWindowMs = 30_000;
@@ -48,12 +54,16 @@ function pageIdentity() {
 function likelySubtitleUrl(url: string) {
     try {
         const parsed = new URL(url, document.baseURI);
-        return /(?:caption|subtitle|timedtext|transcript|\bsubs?\b)/i.test(
+        return /(?:caption|subtit|timedtext|texttrack|transcript|\bsubs?\b)/i.test(
             `${parsed.pathname} ${parsed.searchParams.toString()}`
         );
     } catch {
         return false;
     }
+}
+
+function jsonDiscoveryOptions(url: string) {
+    return { ...aggressiveJsonDiscoveryOptions, rootSubtitleContext: likelySubtitleUrl(url) } as const;
 }
 
 function subtitleExtensionFromText(text: string) {
@@ -146,7 +156,13 @@ function standaloneHlsTrack(manifestUrl: string, manifest: any): VideoDataSubtit
 export class AggressiveGenericPageDiscovery implements VideoDataProvider {
     private readonly baseDiscovery = new BaseGenericPageDiscovery();
     private readonly records: ResourceRecord[] = [];
-    private readonly parsedJson: Array<{ tracks: VideoDataSubtitleTrack[]; page: string; observedAt: number }> = [];
+    private readonly parsedJson: Array<{
+        tracks: VideoDataSubtitleTrack[];
+        metadataUrls: string[];
+        extensionlessTracks: ExtensionlessSubtitleTrack[];
+        page: string;
+        observedAt: number;
+    }> = [];
     private readonly pending = new Set<Promise<unknown>>();
     private originalFetch?: typeof window.fetch;
 
@@ -286,9 +302,13 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         const base = await this.baseDiscovery.videoData(video);
         const page = pageIdentity();
         const tracks = [...(base.subtitles ?? [])];
+        const metadataUrls = new Set<string>();
+        const extensionlessTracks = new Map<string, ExtensionlessSubtitleTrack>();
 
         for (const snapshot of this.parsedJson.filter((snapshot) => snapshot.page === page)) {
             tracks.push(...snapshot.tracks);
+            for (const url of snapshot.metadataUrls) metadataUrls.add(url);
+            for (const track of snapshot.extensionlessTracks) extensionlessTracks.set(track.url, track);
         }
 
         const pageRecords = this.records.filter((record) => record.page === page);
@@ -308,7 +328,10 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
             if (kind === 'json' && text !== undefined) {
                 try {
                     const value = JSON.parse(text);
-                    tracks.push(...tracksFromJson(value, record.url, aggressiveJsonDiscoveryOptions).tracks);
+                    const discovery = tracksFromJson(value, record.url, jsonDiscoveryOptions(record.url));
+                    tracks.push(...discovery.tracks);
+                    for (const url of discovery.metadataUrls) metadataUrls.add(url);
+                    for (const track of discovery.extensionlessTracks) extensionlessTracks.set(track.url, track);
                 } catch {
                     // Ignore malformed JSON metadata.
                 }
@@ -354,6 +377,48 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                 }
             } else if (kind === 'subtitle') {
                 directRecords.push({ record, text });
+            }
+        }
+
+        let speculativeRequests = 0;
+        for (const url of Array.from(metadataUrls).slice(0, maximumMetadataReferences)) {
+            speculativeRequests++;
+            try {
+                const matching = pageRecords.find((record) => record.url === url);
+                const text =
+                    matching === undefined
+                        ? await this.fetchText(url, maximumMetadataBodyLength)
+                        : await this.resourceText(matching);
+                if (text === undefined) continue;
+                const value = JSON.parse(text);
+                if (matching === undefined) this.observe(url, page, 'application/json', text);
+                const discovery = tracksFromJson(value, url, jsonDiscoveryOptions(url));
+                tracks.push(...discovery.tracks);
+            } catch {
+                // Ignore unavailable or malformed speculative subtitle metadata.
+            }
+        }
+
+        for (const candidate of Array.from(extensionlessTracks.values()).slice(
+            0,
+            maximumMetadataReferences - speculativeRequests
+        )) {
+            try {
+                const matching = pageRecords.find((record) => record.url === candidate.url);
+                const text =
+                    matching === undefined
+                        ? await this.fetchText(candidate.url, maximumMetadataBodyLength)
+                        : await this.resourceText(matching);
+                if (text === undefined) continue;
+                const extension =
+                    subtitleExtensionsByContentType[normalizedContentType(matching?.contentType) ?? ''] ??
+                    subtitleExtensionFromText(text);
+                if (extension !== undefined) {
+                    if (matching === undefined) this.observe(candidate.url, page, undefined, text);
+                    tracks.push(trackFromDef({ ...candidate, extension }));
+                }
+            } catch {
+                // Ignore unavailable or unsupported speculative subtitle resources.
             }
         }
 
@@ -420,9 +485,12 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
     }
 
     private rememberJson(value: unknown, page: string, baseUrl: string) {
-        const tracks = deduplicateTracks(tracksFromJson(value, baseUrl, aggressiveJsonDiscoveryOptions).tracks);
-        if (tracks.length === 0) return;
-        this.parsedJson.push({ tracks, page, observedAt: Date.now() });
+        const discovery: JsonDiscovery = tracksFromJson(value, baseUrl, jsonDiscoveryOptions(baseUrl));
+        const tracks = deduplicateTracks(discovery.tracks);
+        const metadataUrls = Array.from(discovery.metadataUrls);
+        const extensionlessTracks = discovery.extensionlessTracks;
+        if (tracks.length === 0 && metadataUrls.length === 0 && extensionlessTracks.length === 0) return;
+        this.parsedJson.push({ tracks, metadataUrls, extensionlessTracks, page, observedAt: Date.now() });
         if (this.parsedJson.length > 20) this.parsedJson.shift();
     }
 
@@ -444,7 +512,7 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
         return record.body === undefined ? this.fetchText(record.url) : record.body;
     }
 
-    private async fetchText(url: string) {
+    private async fetchText(url: string, maximumLength = maximumCapturedBodyLength) {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), resourceFetchTimeoutMs);
         try {
@@ -453,7 +521,7 @@ export class AggressiveGenericPageDiscovery implements VideoDataProvider {
                 signal: controller.signal,
             });
             if (!response.ok && response.status !== 304) return;
-            return await responseTextWithinLimit(response, maximumCapturedBodyLength);
+            return await responseTextWithinLimit(response, maximumLength);
         } finally {
             clearTimeout(timeout);
         }

--- a/extension/src/pages/base-generic-page.test.ts
+++ b/extension/src/pages/base-generic-page.test.ts
@@ -62,6 +62,33 @@ function mockPerformanceEntries(entries: readonly PerformanceEntry[]) {
     };
 }
 
+function mockTextTrack(video: HTMLVideoElement, initialCues: readonly object[]) {
+    let cues = initialCues;
+    const track = new EventTarget() as EventTarget & TextTrack;
+    Object.defineProperties(track, {
+        kind: { configurable: true, value: 'captions' },
+        label: { configurable: true, value: 'English' },
+        language: { configurable: true, value: 'en' },
+        mode: { configurable: true, writable: true, value: 'hidden' },
+        cues: {
+            configurable: true,
+            get: () => Object.assign({}, cues, { length: cues.length }),
+        },
+    });
+    const textTracks = new EventTarget() as EventTarget & TextTrackList;
+    Object.defineProperties(textTracks, {
+        0: { configurable: true, value: track },
+        length: { configurable: true, value: 1 },
+    });
+    Object.defineProperty(video, 'textTracks', { configurable: true, value: textTracks });
+    return {
+        track,
+        setCues(value: readonly object[]) {
+            cues = value;
+        },
+    };
+}
+
 afterEach(() => {
     jest.restoreAllMocks();
     document.body.replaceChildren();
@@ -127,6 +154,24 @@ it('serializes a populated programmatic text track without changing its mode', (
     expect(subtitleTrack.mode).toBe('hidden');
 });
 
+it('does not retain programmatic cues between base discovery requests', async () => {
+    const video = appendVideo();
+    const firstCue = { startTime: 1, endTime: 2, text: 'First' };
+    const secondCue = { startTime: 3, endTime: 4, text: 'Second' };
+    const textTrack = mockTextTrack(video, [firstCue]);
+    const discovery = new BaseGenericPageDiscovery();
+
+    await discovery.videoData(video);
+    textTrack.setCues([secondCue]);
+
+    const data = await discovery.videoData(video);
+    expect(data.subtitles).toHaveLength(1);
+    expect(data.subtitles?.[0]).toMatchObject({ label: 'English', language: 'en', extension: 'srt' });
+    const text = decodeURIComponent((data.subtitles?.[0].url as string).split(',', 2)[1]);
+    expect(text).not.toContain('First');
+    expect(text).toContain('Second');
+});
+
 it('skips unreadable and unreasonably large cue lists', () => {
     const video = appendVideo();
     const unreadableTrack = {
@@ -170,6 +215,36 @@ it('discovers strict subtitle metadata from small explicitly typed inline JSON',
             { label: 'es', language: 'es', url: 'http://localhost/subs/es', extension: 'vtt' },
         ],
     });
+});
+
+it('does not scan a large late hydration payload in base mode', async () => {
+    const video = appendVideo();
+    for (let index = 0; index < 7; index++) appendJson({ analytics: { index } });
+    appendJson({
+        padding: 'x'.repeat(130_000),
+        blockers: Array.from({ length: 700 }, (_, index) => ({ analytics: index })),
+        __DEFAULT_SCOPE__: {
+            webapp: {
+                videoDetail: {
+                    itemInfo: {
+                        itemStruct: {
+                            video: {
+                                subtitleInfos: [
+                                    {
+                                        Url: 'https://cdn.example/timedtext?id=1',
+                                        Format: 'webvtt',
+                                        LanguageCodeName: 'eng-US',
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+    await expect(new BaseGenericPageDiscovery().videoData(video)).resolves.toMatchObject({ subtitles: [] });
 });
 
 it('discovers bounded HLS subtitles from an explicit inline manifest URL', async () => {

--- a/extension/src/pages/base-generic-page.ts
+++ b/extension/src/pages/base-generic-page.ts
@@ -1,12 +1,17 @@
 import type { VideoData, VideoDataSubtitleTrack } from '@project/common';
 import { subtitlesToSrt } from '@project/common/subtitle-reader/subtitles-to-srt';
-import { parseM3U8, subtitleTrackSegmentsFromM3U8Manifest } from '@project/extension/src/pages/m3u8-util';
+import {
+    limitM3U8SubtitleRenditions,
+    parseM3U8,
+    subtitleTrackSegmentsFromM3U8Manifest,
+} from '@project/extension/src/pages/m3u8-util';
 import {
     absoluteHttpUrl,
     absoluteSubtitleUrl,
     basenameForVideo,
     bindVideoDataDiscovery,
     deduplicateTracks,
+    detectedSubtitleLabel,
     isJsonContentType,
     nonEmptyString,
     normalizedContentType,
@@ -17,11 +22,12 @@ import {
 import type { JsonDiscovery, VideoDataProvider } from '@project/extension/src/pages/subtitle-discovery';
 import { trackFromDef } from '@project/extension/src/pages/util';
 
-const maximumInlineJsonScripts = 5;
-const maximumInlineJsonLength = 128_000;
+export const maximumInlineJsonScripts = 5;
+export const maximumInlineJsonLength = 128_000;
 const maximumInlineJsonTotalLength = 256_000;
-const maximumSerializedCues = 10_000;
-const maximumSerializedCueLength = 1_000_000;
+export const maximumTextTrackCues = 10_000;
+export const maximumTextTrackTextLength = 1_000_000;
+export const capturedDuringPlaybackLabelSuffix = ' (captured during playback)';
 const maximumInlineManifestUrls = 3;
 const maximumManifestSubtitleRenditions = 10;
 const maximumManifestSegments = 200;
@@ -82,7 +88,7 @@ function directSubtitleTracksFromPerformance(): VideoDataSubtitleTrack[] {
 
             tracks.push(
                 trackFromDef({
-                    label: language ?? 'Detected subtitle',
+                    label: language ?? detectedSubtitleLabel,
                     language,
                     url,
                     extension,
@@ -100,31 +106,27 @@ interface LoadedM3U8Manifest {
     url: string;
 }
 
+export interface SerializableCue {
+    startTime: number;
+    endTime: number;
+    text: string;
+    source?: object;
+}
+
+export interface AccumulatedTextTrackCues {
+    cues: readonly SerializableCue[];
+    capturedOverTime: boolean;
+}
+
+export interface TextTrackCueProvider {
+    cuesFor(video: HTMLVideoElement, track: TextTrack): AccumulatedTextTrackCues;
+}
+
 function boundedM3U8Manifest(manifest: any) {
     if (Array.isArray(manifest?.segments)) {
         return { ...manifest, segments: manifest.segments.slice(0, maximumManifestSegments) };
     }
     return manifest;
-}
-
-function boundedSubtitleManifest(manifest: any) {
-    const subtitleGroups = manifest?.mediaGroups?.SUBTITLES;
-    if (subtitleGroups === null || typeof subtitleGroups !== 'object') return manifest;
-
-    let remaining = maximumManifestSubtitleRenditions;
-    const groups: Record<string, Record<string, unknown>> = {};
-    for (const [groupId, group] of Object.entries(subtitleGroups)) {
-        if (remaining === 0 || group === null || typeof group !== 'object') break;
-        const entries = Object.entries(group).slice(0, remaining);
-        if (entries.length === 0) continue;
-        groups[groupId] = Object.fromEntries(entries);
-        remaining -= entries.length;
-    }
-
-    return {
-        ...manifest,
-        mediaGroups: { ...manifest.mediaGroups, SUBTITLES: groups },
-    };
 }
 
 async function fetchBoundedM3U8(url: string): Promise<LoadedM3U8Manifest> {
@@ -162,7 +164,7 @@ async function tracksFromInlineManifests(manifestUrls: ReadonlySet<string>) {
             const loadedManifest = await fetchBoundedM3U8(url);
             return subtitleTrackSegmentsFromM3U8Manifest(
                 loadedManifest.url,
-                boundedSubtitleManifest(loadedManifest.manifest),
+                limitM3U8SubtitleRenditions(loadedManifest.manifest, maximumManifestSubtitleRenditions),
                 async (subtitleManifestUrl) => fetchBoundedM3U8(subtitleManifestUrl)
             );
         })
@@ -173,12 +175,11 @@ async function tracksFromInlineManifests(manifestUrls: ReadonlySet<string>) {
     return tracks;
 }
 
-function srtFromTextTrack(track: TextTrack): string | undefined {
+export function cuesFromTextTrack(track: TextTrack): SerializableCue[] {
     try {
-        if (track.cues === null || track.cues.length === 0 || track.cues.length > maximumSerializedCues) return;
+        if (track.cues === null || track.cues.length === 0 || track.cues.length > maximumTextTrackCues) return [];
 
-        const subtitles: { start: number; end: number; text: string }[] = [];
-        let cueTextLength = 0;
+        const cues: SerializableCue[] = [];
         for (const cue of Array.from(track.cues)) {
             const cueText = (cue as VTTCue).text;
             if (
@@ -191,20 +192,34 @@ function srtFromTextTrack(track: TextTrack): string | undefined {
                 continue;
             }
 
-            cueTextLength += cueText.length;
-            if (cueTextLength > maximumSerializedCueLength) return;
-            subtitles.push({ start: cue.startTime * 1000, end: cue.endTime * 1000, text: cueText });
+            cues.push({ startTime: cue.startTime, endTime: cue.endTime, text: cueText, source: cue });
         }
+        return cues;
+    } catch {
+        return [];
+    }
+}
 
-        if (subtitles.length === 0) return;
+function srtFromCues(cues: readonly SerializableCue[]): string | undefined {
+    try {
+        if (cues.length === 0 || cues.length > maximumTextTrackCues) return;
+        let cueTextLength = 0;
+        const subtitles = cues.map((cue) => {
+            cueTextLength += cue.text.length;
+            return { start: cue.startTime * 1000, end: cue.endTime * 1000, text: cue.text };
+        });
+        if (cueTextLength > maximumTextTrackTextLength) return;
         const text = subtitlesToSrt(subtitles);
-        return text.length > maximumSerializedCueLength ? undefined : text;
+        return text.length > maximumTextTrackTextLength ? undefined : text;
     } catch {
         return;
     }
 }
 
-export function nativeSubtitleTracks(video: HTMLVideoElement): VideoDataSubtitleTrack[] {
+export function nativeSubtitleTracks(
+    video: HTMLVideoElement,
+    cueProvider?: TextTrackCueProvider
+): VideoDataSubtitleTrack[] {
     const tracks: VideoDataSubtitleTrack[] = [];
     const elementTextTracks = new Set<TextTrack>();
     const trackElements = Array.from(video.querySelectorAll('track'));
@@ -236,12 +251,18 @@ export function nativeSubtitleTracks(video: HTMLVideoElement): VideoDataSubtitle
             const kind = textTrack.kind.toLowerCase();
             if (kind !== 'subtitles' && kind !== 'captions') continue;
 
-            const text = srtFromTextTrack(textTrack);
+            const accumulated = cueProvider?.cuesFor(video, textTrack) ?? {
+                cues: cuesFromTextTrack(textTrack),
+                capturedOverTime: false,
+            };
+            const text = srtFromCues(accumulated.cues);
             if (text === undefined) continue;
             const language = textTrack.language.trim().toLowerCase() || undefined;
             tracks.push(
                 trackFromDef({
-                    label: textTrack.label.trim() || language || `Subtitle ${trackElements.length + index + 1}`,
+                    label: `${textTrack.label.trim() || language || `Subtitle ${trackElements.length + index + 1}`}${
+                        accumulated.capturedOverTime ? capturedDuringPlaybackLabelSuffix : ''
+                    }`,
                     language,
                     url: `data:application/x-subrip;charset=utf-8,${encodeURIComponent(text)}`,
                     extension: 'srt',
@@ -274,8 +295,10 @@ function subtitleLanguageFromUrl(url: string) {
 }
 
 export class BaseGenericPageDiscovery implements VideoDataProvider {
+    constructor(private readonly cueProvider?: TextTrackCueProvider) {}
+
     async videoData(video: HTMLVideoElement): Promise<VideoData> {
-        const tracks = nativeSubtitleTracks(video);
+        const tracks = nativeSubtitleTracks(video, this.cueProvider);
         tracks.push(...directSubtitleTracksFromPerformance());
         const inlineJson = tracksFromInlineJson();
         tracks.push(...inlineJson.tracks, ...(await tracksFromInlineManifests(inlineJson.manifestUrls)));

--- a/extension/src/pages/base-generic-page.ts
+++ b/extension/src/pages/base-generic-page.ts
@@ -59,7 +59,7 @@ function tracksFromInlineJson(): JsonDiscovery {
         }
     }
 
-    return { tracks, manifestUrls };
+    return { tracks, manifestUrls, metadataUrls: new Set(), extensionlessTracks: [] };
 }
 
 function directSubtitleTracksFromPerformance(): VideoDataSubtitleTrack[] {

--- a/extension/src/pages/base-generic-page.ts
+++ b/extension/src/pages/base-generic-page.ts
@@ -266,6 +266,7 @@ export function nativeSubtitleTracks(
                     language,
                     url: `data:application/x-subrip;charset=utf-8,${encodeURIComponent(text)}`,
                     extension: 'srt',
+                    capturedDuringPlayback: accumulated.capturedOverTime || undefined,
                 })
             );
         }

--- a/extension/src/pages/m3u8-util.test.ts
+++ b/extension/src/pages/m3u8-util.test.ts
@@ -147,6 +147,31 @@ video.m3u8`);
     ]);
 });
 
+it('keeps a URI-bearing subtitle rendition when its optional language is absent', async () => {
+    const loader = async (url: string) => ({
+        manifest: parseM3U8(`#EXTM3U
+#EXTINF:10,
+segment-1.vtt
+#EXT-X-ENDLIST`),
+        url,
+    });
+    const masterManifest = parseM3U8(`#EXTM3U
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",URI="en.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=1280000,SUBTITLES="subs"
+video.m3u8`);
+
+    await expect(
+        subtitleTrackSegmentsFromM3U8Manifest('https://cdn.example/master.m3u8', masterManifest, loader)
+    ).resolves.toMatchObject([
+        {
+            label: 'English',
+            language: undefined,
+            url: ['https://cdn.example/segment-1.vtt'],
+            extension: 'vtt',
+        },
+    ]);
+});
+
 it('resolves segment URIs against the final manifest URL reported by the loader', async () => {
     const loader = async (url: string) => ({
         manifest: parseM3U8(`#EXTM3U

--- a/extension/src/pages/m3u8-util.ts
+++ b/extension/src/pages/m3u8-util.ts
@@ -14,6 +14,26 @@ export function parseM3U8(text: string): any {
     return parser.manifest;
 }
 
+export function limitM3U8SubtitleRenditions(manifest: any, maximumRenditions: number) {
+    const subtitleGroups = manifest?.mediaGroups?.SUBTITLES;
+    if (subtitleGroups === null || typeof subtitleGroups !== 'object') return manifest;
+
+    let remaining = maximumRenditions;
+    const groups: Record<string, Record<string, unknown>> = {};
+    for (const [groupId, group] of Object.entries(subtitleGroups)) {
+        if (remaining === 0 || group === null || typeof group !== 'object') break;
+        const entries = Object.entries(group).slice(0, remaining);
+        if (entries.length === 0) continue;
+        groups[groupId] = Object.fromEntries(entries);
+        remaining -= entries.length;
+    }
+
+    return {
+        ...manifest,
+        mediaGroups: { ...manifest.mediaGroups, SUBTITLES: groups },
+    };
+}
+
 export function fetchM3U8(url: string): Promise<any> {
     return new Promise((resolve, reject) => {
         setTimeout(() => {
@@ -72,7 +92,7 @@ export async function subtitleTrackSegmentsFromM3U8Manifest(
 
                         const track = (group as any)[label];
 
-                        if (track && typeof track.language === 'string' && typeof track.uri === 'string') {
+                        if (track && typeof track.uri === 'string') {
                             const fetchTrack = async (): Promise<VideoDataSubtitleTrack | undefined> => {
                                 const subtitleM3U8Url = new URL(track.uri, url).href;
                                 const loadedManifest = await manifestLoader(subtitleM3U8Url);
@@ -87,7 +107,7 @@ export async function subtitleTrackSegmentsFromM3U8Manifest(
                                 const rawExtension = extractExtension(urls[0], 'vtt').toLowerCase();
                                 return trackFromDef({
                                     label: label,
-                                    language: track.language,
+                                    language: typeof track.language === 'string' ? track.language : undefined,
                                     url: urls,
                                     extension:
                                         // A best-effort heuristic to treat XML subtitle segments in HLS as TTML

--- a/extension/src/pages/subtitle-discovery.test.ts
+++ b/extension/src/pages/subtitle-discovery.test.ts
@@ -6,6 +6,7 @@ import {
     basenameForVideo,
     bindVideoDataDiscovery,
     deduplicateTracks,
+    hasSubtitleMetadataHint,
     isJsonContentType,
     normalizedContentType,
     responseTextWithinLimit,
@@ -64,6 +65,73 @@ it('honors JSON traversal depth and object-count limits', () => {
     expect(tracksFromJson(siblings, 'http://localhost/', { maximumObjects: 3 }).tracks).toMatchObject([
         { url: 'http://localhost/later.vtt' },
     ]);
+});
+
+it('requires paired semantic and track evidence before treating JSON as subtitle metadata', () => {
+    expect(
+        hasSubtitleMetadataHint(
+            JSON.stringify({
+                subtitleInfos: [{ Url: 'https://cdn.example/opaque', Format: 'webvtt' }],
+            })
+        )
+    ).toBe(true);
+    expect(hasSubtitleMetadataHint(JSON.stringify({ subtitlesEnabled: true, format: 'webvtt' }))).toBe(false);
+    expect(hasSubtitleMetadataHint(JSON.stringify({ subtitleInfos: [{ enabled: true }] }))).toBe(false);
+});
+
+it('accepts a supported format as strict subtitle evidence', () => {
+    expect(
+        tracksFromJson(
+            {
+                media: {
+                    Url: 'https://cdn.example/opaque',
+                    Format: 'webvtt',
+                    LanguageCodeName: 'eng-US',
+                    display: 'English auto-generated',
+                },
+            },
+            'https://example.com/watch',
+            { maximumDepth: 2 }
+        ).tracks
+    ).toMatchObject([
+        {
+            label: 'English auto-generated',
+            language: 'eng-us',
+            url: 'https://cdn.example/opaque',
+            extension: 'vtt',
+        },
+    ]);
+});
+
+it('uses baseUrl as a source only inside strong subtitle context', () => {
+    const contextual = tracksFromJson(
+        {
+            captionTracks: [
+                {
+                    baseUrl: 'https://cdn.example/timedtext?id=1',
+                    languageCodeName: 'pt-BR',
+                    fileName: 'Portuguese',
+                },
+            ],
+        },
+        'https://example.com/watch',
+        { contextual: true }
+    );
+
+    expect(contextual.extensionlessTracks).toEqual([
+        {
+            label: 'Portuguese',
+            language: 'pt-br',
+            url: 'https://cdn.example/timedtext?id=1',
+        },
+    ]);
+    expect(
+        tracksFromJson(
+            { baseUrl: 'https://cdn.example/timedtext?id=1', fileName: 'Not contextual' },
+            'https://example.com/watch',
+            { contextual: true }
+        ).extensionlessTracks
+    ).toEqual([]);
 });
 
 it('discovers contextual string tracks but keeps strict discovery unambiguous', () => {

--- a/extension/src/pages/subtitle-discovery.test.ts
+++ b/extension/src/pages/subtitle-discovery.test.ts
@@ -75,6 +75,116 @@ it('discovers contextual string tracks but keeps strict discovery unambiguous', 
     ]);
 });
 
+it('inherits subtitle metadata through namespaced JSON-serialized XML', () => {
+    const metadata = {
+        MPD: [
+            {
+                Period: [
+                    {
+                        SupplementalProperty: [
+                            {
+                                'nvod:SubtitleSet': [
+                                    {
+                                        '@type': 'text/vtt',
+                                        'nvod:Subtitle': [
+                                            {
+                                                '@lang': 'ko',
+                                                'nvod:Source': [
+                                                    {
+                                                        '@type': 'string',
+                                                        '#text': 'https://cdn.example.com/captions/korean',
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+
+    expect(
+        tracksFromJson(metadata, 'https://example.com/watch', {
+            contextual: true,
+            maximumDepth: 12,
+        }).tracks
+    ).toMatchObject([
+        {
+            label: 'ko',
+            language: 'ko',
+            url: 'https://cdn.example.com/captions/korean',
+            extension: 'vtt',
+        },
+    ]);
+});
+
+it('uses response provenance as root subtitle context', () => {
+    const metadata = { page: { items: [{ src: '/resources/spanish.vtt', lang: 'es' }] } };
+
+    expect(tracksFromJson(metadata, 'https://example.com/api/subtitles', { contextual: true }).tracks).toEqual([]);
+    expect(
+        tracksFromJson(metadata, 'https://example.com/api/subtitles', {
+            contextual: true,
+            rootSubtitleContext: true,
+        }).tracks
+    ).toMatchObject([
+        {
+            label: 'es',
+            language: 'es',
+            url: 'https://example.com/resources/spanish.vtt',
+            extension: 'vtt',
+        },
+    ]);
+});
+
+it('returns only strongly identified subtitle metadata references', () => {
+    const discovery = tracksFromJson(
+        {
+            subtitleRef: '/api/video/1/subtitles',
+            imageRef: '/api/video/1/images',
+            hasSubtitles: 'true',
+            captionUrl: 'javascript:alert(1)',
+        },
+        'https://example.com/watch',
+        { contextual: true }
+    );
+
+    expect([...discovery.metadataUrls]).toEqual(['https://example.com/api/video/1/subtitles']);
+});
+
+it('retains extensionless sources only when their own subtitle record has explicit track metadata', () => {
+    const discovery = tracksFromJson(
+        {
+            subtitles: [
+                {
+                    second_subtitle_position: 0,
+                    product_subtitle_language_id: 3,
+                    name: 'English',
+                    language: 'en',
+                    url: 'https://cdn.example/subtitles/opaque-id',
+                },
+                { url: 'https://cdn.example/subtitles/insufficient-evidence' },
+                { subtitle_language_id: 4, url: 'https://cdn.example/video/movie.mp4' },
+                { subtitle_language_id: 5, type: 'video/mp4', url: 'https://cdn.example/video/opaque-id' },
+            ],
+        },
+        'https://example.com/watch',
+        { contextual: true }
+    );
+
+    expect(discovery.extensionlessTracks).toEqual([
+        {
+            label: 'English',
+            language: 'en',
+            url: 'https://cdn.example/subtitles/opaque-id',
+        },
+    ]);
+});
+
 it('bounds both buffered and streaming response bodies', async () => {
     const bufferedResponse = (text: string) => ({ body: null, text: async () => text }) as unknown as Response;
 

--- a/extension/src/pages/subtitle-discovery.ts
+++ b/extension/src/pages/subtitle-discovery.ts
@@ -15,6 +15,7 @@ const subtitleContainerKeys = new Set([
     'captions',
     'subtitle',
     'subtitles',
+    'subtitleset',
     'subtitletracks',
     'texttracks',
     'tracks',
@@ -80,45 +81,76 @@ export function nonEmptyString(value: unknown) {
 interface TrackDefinitionOptions {
     strict: boolean;
     subtitleContext: boolean;
+    inheritedContentType?: string;
+    inheritedLanguage?: string;
+}
+
+function normalizedMetadataKey(key: string) {
+    const localName = key.slice(key.lastIndexOf(':') + 1);
+    return localName.replace(/^[@#]/, '').toLowerCase();
+}
+
+function metadataString(value: JsonRecord, keys: readonly string[]) {
+    for (const expectedKey of keys) {
+        for (const [key, candidate] of Object.entries(value)) {
+            if (normalizedMetadataKey(key) !== expectedKey) continue;
+            const stringValue = nonEmptyString(candidate);
+            if (stringValue !== undefined) return stringValue;
+        }
+    }
+    return;
+}
+
+function subtitleContentType(value: JsonRecord) {
+    const contentType = normalizedContentType(metadataString(value, ['mimetype', 'contenttype', 'type']));
+    return subtitleExtensionsByContentType[contentType ?? ''] === undefined ? undefined : contentType;
+}
+
+function metadataLanguage(value: JsonRecord) {
+    return metadataString(value, ['srclang', 'language', 'lang', 'locale'])?.toLowerCase();
+}
+
+function subtitleReferenceUrl(key: string, value: string, baseUrl: string) {
+    const normalizedKey = normalizedMetadataKey(key);
+    if (!/(?:caption|subtit|timedtext|texttrack|transcript)/.test(normalizedKey)) return;
+    if (!/(?:endpoint|href|ref|uri|url)$/.test(normalizedKey)) return;
+    if (!/^(?:https?:)?\/\/|^\.{0,2}\//i.test(value)) return;
+    return absoluteHttpUrl(value, baseUrl);
 }
 
 function trackDefinitionFromMetadata(
     value: JsonRecord,
     baseUrl: string,
-    { strict, subtitleContext }: TrackDefinitionOptions
+    { strict, subtitleContext, inheritedContentType, inheritedLanguage }: TrackDefinitionOptions
 ): VideoDataSubtitleTrackDef | undefined {
-    const kind = nonEmptyString(value.kind)?.toLowerCase();
-    const semanticType = nonEmptyString(value.type)?.toLowerCase();
+    const kind = metadataString(value, ['kind'])?.toLowerCase();
+    const semanticType = metadataString(value, ['type'])?.toLowerCase();
     const declaredKind =
         kind ?? (semanticType === 'subtitles' || semanticType === 'captions' ? semanticType : undefined);
-    const contentType = normalizedContentType(value.mimeType ?? value.contentType ?? value.type);
-    const contentTypeExtension = subtitleExtensionsByContentType[contentType ?? ''];
+    const declaredContentType = normalizedContentType(metadataString(value, ['mimetype', 'contenttype', 'type']));
+    const declaredContentTypeExtension = subtitleExtensionsByContentType[declaredContentType ?? ''];
+    const contentTypeExtension =
+        declaredContentTypeExtension ?? subtitleExtensionsByContentType[inheritedContentType ?? ''];
 
     // Explicit non-subtitle kinds win over a subtitle-looking URL or MIME type.
     if (declaredKind !== undefined && declaredKind !== 'subtitles' && declaredKind !== 'captions') return;
     if (!subtitleContext && declaredKind === undefined && contentTypeExtension === undefined) return;
-    if (strict && contentType?.includes('/') === true && contentTypeExtension === undefined) return;
+    if (strict && declaredContentType?.includes('/') === true && declaredContentTypeExtension === undefined) return;
 
-    const source = nonEmptyString(value.src) ?? nonEmptyString(value.file) ?? nonEmptyString(value.url);
+    const source = metadataString(value, ['src', 'file', 'url', 'source', 'text']);
     if (source === undefined) return;
 
     const url = absoluteSubtitleUrl(source, baseUrl);
     if (url === undefined) return;
 
-    const format = nonEmptyString(value.format);
+    const format = metadataString(value, ['format']);
     const formatExtension = format === undefined ? undefined : normalizeSubtitleExtension(format.replace(/^\./, ''));
     if (strict && format !== undefined && formatExtension === undefined) return;
     const extension = formatExtension ?? contentTypeExtension ?? subtitleExtensionForUrl(url);
     if (extension === undefined) return;
 
-    const language =
-        nonEmptyString(value.srclang) ??
-        nonEmptyString(value.srcLang) ??
-        nonEmptyString(value.language) ??
-        nonEmptyString(value.lang);
-    const normalizedLanguage = language?.toLowerCase();
-    const label =
-        nonEmptyString(value.label) ?? nonEmptyString(value.name) ?? normalizedLanguage ?? 'Detected subtitle';
+    const normalizedLanguage = metadataLanguage(value) ?? inheritedLanguage;
+    const label = metadataString(value, ['label', 'name']) ?? normalizedLanguage ?? 'Detected subtitle';
 
     return { label, language: normalizedLanguage, url, extension };
 }
@@ -126,12 +158,21 @@ function trackDefinitionFromMetadata(
 export interface JsonDiscovery {
     tracks: VideoDataSubtitleTrack[];
     manifestUrls: Set<string>;
+    metadataUrls: Set<string>;
+    extensionlessTracks: ExtensionlessSubtitleTrack[];
+}
+
+export interface ExtensionlessSubtitleTrack {
+    label: string;
+    language?: string;
+    url: string;
 }
 
 export interface JsonDiscoveryOptions {
     contextual?: boolean;
     maximumDepth?: number;
     maximumObjects?: number;
+    rootSubtitleContext?: boolean;
 }
 
 function manifestUrlFromJson(value: JsonRecord, baseUrl: string): string | undefined {
@@ -144,16 +185,24 @@ function manifestUrlFromJson(value: JsonRecord, baseUrl: string): string | undef
 }
 
 export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDiscoveryOptions = {}): JsonDiscovery {
-    if (value === null || typeof value !== 'object') return { tracks: [], manifestUrls: new Set() };
+    if (value === null || typeof value !== 'object') {
+        return { tracks: [], manifestUrls: new Set(), metadataUrls: new Set(), extensionlessTracks: [] };
+    }
 
     const contextual = options.contextual === true;
     const depthLimit = options.maximumDepth ?? maximumJsonDepth;
     const objectLimit = options.maximumObjects ?? maximumJsonObjects;
     const tracks: VideoDataSubtitleTrack[] = [];
     const manifestUrls = new Set<string>();
-    const queue: Array<{ value: object; depth: number; subtitleContext: boolean }> = [
-        { value, depth: 0, subtitleContext: false },
-    ];
+    const metadataUrls = new Set<string>();
+    const extensionlessTracks: ExtensionlessSubtitleTrack[] = [];
+    const queue: Array<{
+        value: object;
+        depth: number;
+        subtitleContext: boolean;
+        inheritedContentType?: string;
+        inheritedLanguage?: string;
+    }> = [{ value, depth: 0, subtitleContext: contextual && options.rootSubtitleContext === true }];
     let next = 0;
     let visited = 0;
 
@@ -163,22 +212,75 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
 
         try {
             const record = current.value as JsonRecord;
+            const inheritedContentType = subtitleContentType(record) ?? current.inheritedContentType;
+            const inheritedLanguage = metadataLanguage(record) ?? current.inheritedLanguage;
             const manifestUrl = manifestUrlFromJson(record, baseUrl);
             if (manifestUrl !== undefined) manifestUrls.add(manifestUrl);
 
             const definition = trackDefinitionFromMetadata(record, baseUrl, {
                 strict: !contextual,
                 subtitleContext: current.subtitleContext,
+                inheritedContentType,
+                inheritedLanguage,
             });
             if (definition !== undefined) tracks.push(trackFromDef(definition));
+            else if (contextual && current.subtitleContext) {
+                const kind = metadataString(record, ['kind'])?.toLowerCase();
+                const declaredType = normalizedContentType(metadataString(record, ['mimetype', 'contenttype', 'type']));
+                const hasExplicitSubtitleMetadata = Object.keys(record).some((key) => {
+                    const normalizedKey = normalizedMetadataKey(key);
+                    return (
+                        /(?:caption|subtit|timedtext|texttrack|transcript)/.test(normalizedKey) &&
+                        /(?:code|format|id|kind|label|lang|language|locale|name|position|source|src|type|uri|url)/.test(
+                            normalizedKey
+                        )
+                    );
+                });
+                const source = metadataString(record, ['src', 'file', 'url', 'source', 'text']);
+                const url = source === undefined ? undefined : absoluteHttpUrl(source, baseUrl);
+                if (
+                    hasExplicitSubtitleMetadata &&
+                    (kind === undefined || kind === 'subtitles' || kind === 'captions') &&
+                    (declaredType === undefined ||
+                        !declaredType.includes('/') ||
+                        subtitleExtensionsByContentType[declaredType] !== undefined) &&
+                    url !== undefined &&
+                    extractExtension(url, '') === '' &&
+                    !extensionlessTracks.some((track) => track.url === url)
+                ) {
+                    const language = metadataLanguage(record) ?? inheritedLanguage;
+                    const label = metadataString(record, ['label', 'name']) ?? language ?? 'Detected subtitle';
+                    extensionlessTracks.push({ label, language, url });
+                }
+            }
 
             if (current.depth >= depthLimit) continue;
             for (const [key, child] of Object.entries(current.value)) {
                 const subtitleContext =
-                    current.subtitleContext || (contextual && subtitleContainerKeys.has(key.toLowerCase()));
+                    current.subtitleContext || (contextual && subtitleContainerKeys.has(normalizedMetadataKey(key)));
                 if (child !== null && typeof child === 'object') {
-                    queue.push({ value: child, depth: current.depth + 1, subtitleContext });
-                } else if (subtitleContext && typeof child === 'string') {
+                    queue.push({
+                        value: child,
+                        depth: current.depth + 1,
+                        subtitleContext,
+                        inheritedContentType,
+                        inheritedLanguage,
+                    });
+                } else if (contextual && typeof child === 'string') {
+                    const referenceUrl = subtitleReferenceUrl(key, child, baseUrl);
+                    const referenceExtension =
+                        referenceUrl === undefined ? undefined : subtitleExtensionForUrl(referenceUrl);
+                    if (referenceUrl !== undefined && referenceExtension === undefined) metadataUrls.add(referenceUrl);
+                    else if (referenceUrl !== undefined && referenceExtension !== undefined) {
+                        tracks.push(
+                            trackFromDef({
+                                label: inheritedLanguage ?? normalizedMetadataKey(key),
+                                url: referenceUrl,
+                                extension: referenceExtension,
+                            })
+                        );
+                    }
+                    if (definition !== undefined || !subtitleContext) continue;
                     const url = absoluteSubtitleUrl(child, baseUrl);
                     const extension = url === undefined ? undefined : subtitleExtensionForUrl(url);
                     if (url !== undefined && extension !== undefined) {
@@ -191,7 +293,7 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
         }
     }
 
-    return { tracks, manifestUrls };
+    return { tracks, manifestUrls, metadataUrls, extensionlessTracks };
 }
 
 export async function responseTextWithinLimit(response: Response, maximumLength: number, timeoutMs?: number) {

--- a/extension/src/pages/subtitle-discovery.ts
+++ b/extension/src/pages/subtitle-discovery.ts
@@ -9,17 +9,26 @@ type JsonRecord = Record<string, unknown>;
 
 const maximumJsonObjects = 100;
 const maximumJsonDepth = 4;
+export const detectedSubtitleLabel = 'Detected subtitle';
 const manifestUrlFields = new Set(['hls', 'hlsurl', 'm3u8', 'm3u8url', 'manifesturl', 'playlisturl']);
 const subtitleContainerKeys = new Set([
     'caption',
+    'captiontracks',
     'captions',
     'subtitle',
+    'subtitleinfos',
     'subtitles',
     'subtitleset',
     'subtitletracks',
     'texttracks',
     'tracks',
 ]);
+const supportedFormatHint = /"format"\s*:\s*"(?:\.?(?:ass|dfxp|srt|ssa|ttml2?|vtt)|subrip|webvtt)"/i;
+const subtitleContainerHint =
+    /"(?:captions?|captiontracks?|subtitles?|subtitleinfos?|subtitleset|subtitletracks?|texttracks?|timedtext|transcripts?)"\s*:/i;
+const subtitleSourceHint =
+    /"(?:baseurl|file|src|source|url)"\s*:\s*"[^"]*(?:caption|subtit|texttrack|timedtext|transcript|\.ass(?:[?#]|$)|\.dfxp(?:[?#]|$)|\.srt(?:[?#]|$)|\.ssa(?:[?#]|$)|\.ttml(?:[?#]|$)|\.vtt(?:[?#]|$))/i;
+const subtitleKindHint = /"kind"\s*:\s*"(?:captions?|subtitles?)"/i;
 
 export const subtitleExtensionsByContentType: Readonly<Record<string, string>> = {
     'application/dfxp+xml': 'dfxp',
@@ -78,6 +87,13 @@ export function nonEmptyString(value: unknown) {
     return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+export function hasSubtitleMetadataHint(text: string) {
+    return (
+        subtitleContainerHint.test(text) &&
+        (supportedFormatHint.test(text) || subtitleSourceHint.test(text) || subtitleKindHint.test(text))
+    );
+}
+
 interface TrackDefinitionOptions {
     strict: boolean;
     subtitleContext: boolean;
@@ -107,7 +123,20 @@ function subtitleContentType(value: JsonRecord) {
 }
 
 function metadataLanguage(value: JsonRecord) {
-    return metadataString(value, ['srclang', 'language', 'lang', 'locale'])?.toLowerCase();
+    return metadataString(value, ['srclang', 'language', 'languagecodename', 'lang', 'locale'])?.toLowerCase();
+}
+
+function metadataLabel(value: JsonRecord) {
+    return metadataString(value, ['label', 'name', 'display', 'filename']);
+}
+
+function metadataSource(value: JsonRecord, subtitleContext: boolean, declaredKind?: string) {
+    const source = metadataString(value, ['src', 'file', 'url', 'source', 'text']);
+    if (source !== undefined) return source;
+    if (subtitleContext || declaredKind === 'subtitles' || declaredKind === 'captions') {
+        return metadataString(value, ['baseurl']);
+    }
+    return;
 }
 
 function subtitleReferenceUrl(key: string, value: string, baseUrl: string) {
@@ -131,26 +160,33 @@ function trackDefinitionFromMetadata(
     const declaredContentTypeExtension = subtitleExtensionsByContentType[declaredContentType ?? ''];
     const contentTypeExtension =
         declaredContentTypeExtension ?? subtitleExtensionsByContentType[inheritedContentType ?? ''];
+    const format = metadataString(value, ['format']);
+    const formatExtension = format === undefined ? undefined : normalizeSubtitleExtension(format.replace(/^\./, ''));
 
     // Explicit non-subtitle kinds win over a subtitle-looking URL or MIME type.
     if (declaredKind !== undefined && declaredKind !== 'subtitles' && declaredKind !== 'captions') return;
-    if (!subtitleContext && declaredKind === undefined && contentTypeExtension === undefined) return;
     if (strict && declaredContentType?.includes('/') === true && declaredContentTypeExtension === undefined) return;
+    if (strict && format !== undefined && formatExtension === undefined) return;
+    if (
+        !subtitleContext &&
+        declaredKind === undefined &&
+        contentTypeExtension === undefined &&
+        formatExtension === undefined
+    ) {
+        return;
+    }
 
-    const source = metadataString(value, ['src', 'file', 'url', 'source', 'text']);
+    const source = metadataSource(value, subtitleContext, declaredKind);
     if (source === undefined) return;
 
     const url = absoluteSubtitleUrl(source, baseUrl);
     if (url === undefined) return;
 
-    const format = metadataString(value, ['format']);
-    const formatExtension = format === undefined ? undefined : normalizeSubtitleExtension(format.replace(/^\./, ''));
-    if (strict && format !== undefined && formatExtension === undefined) return;
     const extension = formatExtension ?? contentTypeExtension ?? subtitleExtensionForUrl(url);
     if (extension === undefined) return;
 
     const normalizedLanguage = metadataLanguage(value) ?? inheritedLanguage;
-    const label = metadataString(value, ['label', 'name']) ?? normalizedLanguage ?? 'Detected subtitle';
+    const label = metadataLabel(value) ?? normalizedLanguage ?? detectedSubtitleLabel;
 
     return { label, language: normalizedLanguage, url, extension };
 }
@@ -236,10 +272,19 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                         )
                     );
                 });
-                const source = metadataString(record, ['src', 'file', 'url', 'source', 'text']);
+                const format = metadataString(record, ['format']);
+                const formatExtension =
+                    format === undefined ? undefined : normalizeSubtitleExtension(format.replace(/^\./, ''));
+                const language = metadataLanguage(record) ?? inheritedLanguage;
+                const label = metadataLabel(record);
+                const source = metadataSource(record, true, kind);
                 const url = source === undefined ? undefined : absoluteHttpUrl(source, baseUrl);
                 if (
-                    hasExplicitSubtitleMetadata &&
+                    (hasExplicitSubtitleMetadata ||
+                        kind === 'subtitles' ||
+                        kind === 'captions' ||
+                        formatExtension !== undefined ||
+                        (url !== undefined && (language !== undefined || label !== undefined))) &&
                     (kind === undefined || kind === 'subtitles' || kind === 'captions') &&
                     (declaredType === undefined ||
                         !declaredType.includes('/') ||
@@ -248,9 +293,7 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                     extractExtension(url, '') === '' &&
                     !extensionlessTracks.some((track) => track.url === url)
                 ) {
-                    const language = metadataLanguage(record) ?? inheritedLanguage;
-                    const label = metadataString(record, ['label', 'name']) ?? language ?? 'Detected subtitle';
-                    extensionlessTracks.push({ label, language, url });
+                    extensionlessTracks.push({ label: label ?? language ?? detectedSubtitleLabel, language, url });
                 }
             }
 
@@ -284,7 +327,7 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                     const url = absoluteSubtitleUrl(child, baseUrl);
                     const extension = url === undefined ? undefined : subtitleExtensionForUrl(url);
                     if (url !== undefined && extension !== undefined) {
-                        tracks.push(trackFromDef({ label: key || 'Detected subtitle', url, extension }));
+                        tracks.push(trackFromDef({ label: key || detectedSubtitleLabel, url, extension }));
                     }
                 }
             }

--- a/extension/src/services/binding.test.ts
+++ b/extension/src/services/binding.test.ts
@@ -373,7 +373,7 @@ describe('Binding playback mode integration', () => {
         video.dispatchEvent(new Event('loadedmetadata'));
         await jest.advanceTimersByTimeAsync(0);
 
-        expect(requestSubtitles).toHaveBeenCalledWith({ videoChanged: true });
+        expect(requestSubtitles).toHaveBeenCalledWith({ kind: 'reload', videoChanged: true });
         expect(resetSubtitles).toHaveBeenCalledTimes(1);
         expect(displayedSubtitleTexts()).toEqual([]);
         binding.unbind();
@@ -397,7 +397,7 @@ describe('Binding playback mode integration', () => {
         video.dispatchEvent(new Event('loadedmetadata'));
         await jest.advanceTimersByTimeAsync(0);
 
-        expect(requestSubtitles).toHaveBeenCalledWith({ videoChanged: true });
+        expect(requestSubtitles).toHaveBeenCalledWith({ kind: 'reload', videoChanged: true });
         expect(resetSubtitles).toHaveBeenCalledTimes(1);
         binding.unbind();
     });

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -631,7 +631,7 @@ export default class Binding {
         this._notifyReady();
         this._subscribe();
         void this._refreshSettings().then(() => {
-            void this.videoDataSyncController.requestSubtitles({ videoChanged: false });
+            void this.videoDataSyncController.requestSubtitles({ kind: 'reload', videoChanged: false });
         });
         this.subtitleController.bind();
         this.playbackEngine.bind();
@@ -781,7 +781,7 @@ export default class Binding {
         if (this.hasPageScript) {
             const debouncedChangeListener = debounced(
                 (videoChanged: boolean) => {
-                    void this.videoDataSyncController.requestSubtitles({ videoChanged });
+                    void this.videoDataSyncController.requestSubtitles({ kind: 'reload', videoChanged });
                     this._resetSubtitles();
                 },
                 disneyPlus ? 1000 : 0

--- a/extension/src/services/pages.test.ts
+++ b/extension/src/services/pages.test.ts
@@ -110,6 +110,7 @@ it('uses non-autosyncing generic discovery when enabled for an unsupported site'
     expect(page.config).toMatchObject({
         pageScript: 'base-generic-page.js',
         generic: true,
+        refreshSubtitleDataOnPickerOpen: true,
         searchShadowRootsForVideoElements: false,
         autoSync: { enabled: false },
     });
@@ -159,6 +160,7 @@ it('uses aggressive discovery and searches shadow roots in aggressive mode', () 
     expect(page.config).toMatchObject({
         pageScript: 'aggressive-generic-page.js',
         generic: true,
+        refreshSubtitleDataOnPickerOpen: true,
         searchShadowRootsForVideoElements: true,
         autoSync: { enabled: false },
     });

--- a/extension/src/services/pages.ts
+++ b/extension/src/services/pages.ts
@@ -31,6 +31,9 @@ export interface PageConfig {
     // Whether this is the generic fallback used for otherwise unsupported pages
     generic?: boolean;
 
+    // Whether to refresh available subtitle tracks when the subtitle picker opens
+    refreshSubtitleDataOnPickerOpen?: boolean;
+
     // Whether a changed media source identifies a new video even when the page URL is unchanged
     videoSrcChangesIndicateNewVideo?: boolean;
 
@@ -141,6 +144,7 @@ export function pageDelegateForUrl(
         host: page?.host ?? urlObj.host,
         pageScript: aggressiveGenericSubtitleParserEnabled ? aggressiveGenericPageScript : baseGenericPageScript,
         generic: true,
+        refreshSubtitleDataOnPickerOpen: true,
         searchShadowRootsForVideoElements:
             page?.searchShadowRootsForVideoElements ?? aggressiveGenericSubtitleParserEnabled,
         autoSync: { ...page?.autoSync, enabled: false },

--- a/loc/notes.json
+++ b/loc/notes.json
@@ -177,6 +177,7 @@
         "ftue.welcomeBody": "Text that is displayed when user installs asbplayer for the first time.",
         "info.connectionFailed": "Helper text in settings dialog indicating WebSocket connection failed.",
         "info.connectionSucceeded": "Helper text in settings dialog indicating WebSocket connection succeeded.",
+        "info.refreshForChangesToTakeEffect": "Information shown after changing a setting that requires the page to be refreshed.",
         "info.copiedSubtitle": "Text that is displayed when asbplayer mines a subtitle.",
         "info.copiedSubtitle2": "Notification displayed when user copies/mines a subtitle.",
         "info.disabledAutoPause": "Displayed when user toggles off auto-pause playback mode.",


### PR DESCRIPTION
As mentioned here, https://github.com/asbplayer/asbplayer/pull/1144#issuecomment-5418075326, I went and checked 200+ sites for this feature to get some proper statistics and find any other meaningful improvements. I was able to resolve some of the failures as well as some UX improvements. I think this PR essentially puts this parser in its final state as there are no more generic improvements we can make from my extensive collection.

But first the statistics (as of this PR):

| Result | Sites | Rate |
| --- | ---: | ---: |
| **Base works without selection** | 23 / 86 | **26.7%** |
| **Base works overall** | 54 / 86 | **62.8%** |
| **Base requires subtitle selection** | 31 / 86 | **36.0%** |
| **Aggressive works without selection** | 56 / 86 | **65.1%** |
| **Aggressive works overall** | 73 / 86 | **84.9%** |
| **Aggressive requires subtitle selection** | 17 / 86 | **19.8%** |
| **Aggressive-only rescue** | 19 / 86 | **22.1%** |
| **Fail even with Aggressive** | 13 / 86 | **15.1%** |

The key number is that `~85%` of tested sites (checked 200+) with subtitle detection possible is discovered by the generic parser (far greater than my original estimate of 25%-50%). I was originally hoping for a number ~80% when first developing this feature so I'm happy with where it landed up.

The checked sites covered the most popular video based websites for numerous languages and media types which should be a representative sample of the contexts where asbplayer could be used. The final number for the stats is much lower due to a lot of sites either being hardcoded subs, no subs, or requiring an account or subscription (which shouldn't affect the population distribution for this test).

My intention for this feature still stands from the comment linked above:
> Yes I agree, this should never get in the way of these integrations, if anything that should mean they are relatively easy integration. Even if someone were to request a site with perfect base generic support (for example Natural Japanese), it's still worth adding in my opinion.

> I don't think it's a good value of anyone's time to add integrations without explicit requests, so this serves cater to those cases. I do plan on adding specific integrations for many sites when it becomes the most valuable thing I can do, but right now there are much bigger priorities for asbplayer especially after this change.

Otherwise for the changes:
- Update the docs with the `~85%` efficacy as well as the statement that it doesn't preclude specific integrations
- Added a message to refresh the page when changing the generic parser (at least one user would otherwise miss this)
  - I made this text as generic as possible so it can potentially be reused in the future
- Opening the picker when for a generic page will trigger a reload of the subtitle data
  - If new data is present, the subtitle picker dialog will be refreshed
  - This is necessary for the sites which only work by selected subtitles. Most will preserve the subtitle selection through a page refresh, but some don't and this gives better UX where they can just select the subtitle and open the picker.
- All improvements were pretty much in aggressive mode, both modes gained some improvement in metadata parsing however

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6