### PR TITLE
Fix inconsistent fullscreen and non-fullscreen subtitle styles

### DIFF
--- a/common/app/components/subtitles.css
+++ b/common/app/components/subtitles.css
@@ -7,7 +7,7 @@
 .asbplayer-subtitles {
     margin: 0;
     padding: 0;
-    display: table;
+    display: inline-block; /* Chromium can discard newline-only text nodes between inline children during table layout. */
     margin: auto;
     white-space: pre-wrap !important;
 }

--- a/common/util/util.test.ts
+++ b/common/util/util.test.ts
@@ -521,11 +521,17 @@ describe('extractText', () => {
 
 describe('computeStyles and computeStyleString', () => {
     it('returns base styles when optional decorations are disabled', () => {
-        expect(computeStyles(textSubtitleSettings())).toEqual({
+        const settings = textSubtitleSettings();
+
+        expect(computeStyles(settings)).toEqual({
             color: '#FFFFFF',
             fontSize: '32px',
             fontWeight: '700',
+            WebkitTextStroke: '0 transparent',
+            textShadow: 'none',
         });
+        expect(computeStyleString(settings)).toContain('-webkit-text-stroke: 0 transparent !important');
+        expect(computeStyleString(settings)).toContain('text-shadow: none !important');
     });
 
     it('applies outline, shadow, background, font family, and custom styles while ignoring numeric keys', () => {

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -444,6 +444,8 @@ export function computeStyles(
         color: subtitleColor,
         fontSize: `${subtitleSize}px`,
         fontWeight: String(subtitleThickness),
+        WebkitTextStroke: '0 transparent',
+        textShadow: 'none',
     };
 
     if (subtitleOutlineThickness > 0) {

--- a/extension/src/controllers/subtitle-controller.test.ts
+++ b/extension/src/controllers/subtitle-controller.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import type { DictionaryProvider } from '@project/common/dictionary-db';
+import { defaultSettings } from '@project/common/settings';
+import type { SettingsProvider } from '@project/common/settings';
+import SubtitleController from '@project/extension/src/controllers/subtitle-controller';
+import type Binding from '@project/extension/src/services/binding';
+
+describe('SubtitleController appearance rendering', () => {
+    const controllers: SubtitleController[] = [];
+
+    afterEach(() => {
+        for (const controller of controllers) controller.unbind();
+        controllers.length = 0;
+        document.body.replaceChildren();
+    });
+
+    const controllerForVideo = () => {
+        const video = document.createElement('video');
+        video.getBoundingClientRect = () => ({ left: 0, top: 0, width: 640, height: 360 }) as DOMRect;
+        const controller = new SubtitleController(
+            {
+                video,
+                registeredVideoSrc: 'https://example.com/video.mp4',
+                currentTimeMs: 0,
+            } as unknown as Binding,
+            { publishStatisticsSnapshot: async () => {} } as unknown as DictionaryProvider,
+            {
+                activeProfile: async () => undefined,
+                getAll: async () => defaultSettings,
+                getSingle: async (key: keyof typeof defaultSettings) => defaultSettings[key],
+            } as unknown as SettingsProvider
+        );
+        controllers.push(controller);
+        return controller;
+    };
+
+    it('keeps cached image subtitle width responsive and rebuilds its ratio when image scale changes', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings({ ...defaultSettings, imageBasedSubtitleScaleFactor: 2 });
+        controller.subtitles = [
+            {
+                text: '',
+                textImage: {
+                    dataUrl: 'data:image/png;base64,image',
+                    screen: { width: 100, height: 50 },
+                    image: { width: 25, height: 10 },
+                },
+                start: 0,
+                end: 1000,
+                originalStart: 0,
+                originalEnd: 1000,
+                track: 0,
+                index: 0,
+            },
+        ];
+        controller.cacheHtml();
+
+        let imageContainer = document.querySelector<HTMLImageElement>('img[alt="subtitle"]')?.parentElement;
+        expect(imageContainer?.dataset.asbVideoWidthRatio).toBe('0.5');
+        expect(imageContainer?.style.maxWidth).toBe('100%');
+        expect(imageContainer?.getAttributeNames()).not.toContain('}');
+
+        controller.setSubtitleSettings({ ...defaultSettings, imageBasedSubtitleScaleFactor: 4 });
+
+        imageContainer = document.querySelector<HTMLImageElement>('img[alt="subtitle"]')?.parentElement;
+        expect(imageContainer?.dataset.asbVideoWidthRatio).toBe('1');
+    });
+
+    it('falls back to track zero subtitle classes for tracks without appearance settings', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings({ ...defaultSettings, subtitleBlur: true });
+        controller.subtitles = [
+            {
+                text: 'subtitle',
+                start: 0,
+                end: 1000,
+                originalStart: 0,
+                originalEnd: 1000,
+                track: 5,
+                index: 0,
+            },
+            {
+                text: '',
+                textImage: {
+                    dataUrl: 'data:image/png;base64,image',
+                    screen: { width: 100, height: 50 },
+                    image: { width: 25, height: 10 },
+                },
+                start: 0,
+                end: 1000,
+                originalStart: 0,
+                originalEnd: 1000,
+                track: 6,
+                index: 1,
+            },
+        ];
+        controller.cacheHtml();
+
+        expect(document.querySelector('span[data-track="5"]')?.className).toBe('asbplayer-subtitles-blurred');
+        expect(document.querySelector('div[data-track="6"]')?.className).toBe('asbplayer-subtitles-blurred');
+    });
+
+    it('rerenders the current subtitle when appearance or alignment settings change', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings({ ...defaultSettings, subtitleColor: '#ff0000' });
+        controller.subtitles = [
+            {
+                text: 'subtitle',
+                start: 0,
+                end: 1000,
+                originalStart: 0,
+                originalEnd: 1000,
+                track: 0,
+                index: 0,
+            },
+        ];
+        controller.cacheHtml();
+        controller.playbackStateChanged({ timestampMs: 0, showingSubtitleIndexes: [0], paused: false });
+
+        expect(document.querySelector('.asbplayer-subtitles-container-bottom span')?.getAttribute('style')).toContain(
+            'color: #ff0000'
+        );
+
+        controller.setSubtitleSettings({
+            ...defaultSettings,
+            subtitleColor: '#0000ff',
+            subtitleAlignment: 'top',
+        });
+
+        expect(document.querySelector('.asbplayer-subtitles-container-bottom span')).toBeNull();
+        expect(document.querySelector('.asbplayer-subtitles-container-top span')?.getAttribute('style')).toContain(
+            'color: #0000ff'
+        );
+    });
+});

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -227,21 +227,29 @@ export default class SubtitleController {
     }
 
     setSubtitleSettings(newSubtitleSettings: SubtitleSettings) {
+        const imageScaleChanged =
+            this.subtitleSettings?.imageBasedSubtitleScaleFactor !== newSubtitleSettings.imageBasedSubtitleScaleFactor;
+        this.subtitleSettings = newSubtitleSettings;
         const styles = this._computeStyles(newSubtitleSettings);
         const classes = this._computeClasses(newSubtitleSettings);
-        if (
+        const textAppearanceChanged =
             this.subtitleStyles === undefined ||
             !arrayEquals(styles, this.subtitleStyles, (a, b) => a === b) ||
             this.subtitleClasses === undefined ||
-            !arrayEquals(classes, this.subtitleClasses, (a, b) => a === b)
-        ) {
+            !arrayEquals(classes, this.subtitleClasses, (a, b) => a === b);
+        if (textAppearanceChanged || imageScaleChanged) {
             this.subtitleStyles = styles;
             this.subtitleClasses = classes;
             this.cacheHtml();
         }
 
         const newAlignments = allTextSubtitleSettings(newSubtitleSettings).map((s) => s.subtitleAlignment);
-        if (!arrayEquals(newAlignments, Object.values(this.subtitleTrackAlignments), (a, b) => a === b)) {
+        const alignmentChanged = !arrayEquals(
+            newAlignments,
+            Object.values(this.subtitleTrackAlignments),
+            (a, b) => a === b
+        );
+        if (alignmentChanged) {
             this.subtitleTrackAlignments = newAlignments;
             this.shouldRenderBottomOverlay = Object.values(this.subtitleTrackAlignments).includes('bottom');
             this.shouldRenderTopOverlay = Object.values(this.subtitleTrackAlignments).includes('top');
@@ -257,8 +265,10 @@ export default class SubtitleController {
         }
 
         this.unblurredSubtitleTracks = {};
-
-        this.subtitleSettings = newSubtitleSettings;
+        if (textAppearanceChanged || imageScaleChanged || alignmentChanged) {
+            this.refreshCurrentSubtitle = true;
+            this.refreshShowingSubtitles();
+        }
     }
 
     private _computeStyles(settings: SubtitleSettings) {
@@ -522,17 +532,16 @@ export default class SubtitleController {
             return {
                 html: () => {
                     if (subtitle.textImage) {
-                        const className = this.subtitleClasses?.[subtitle.track] ?? '';
-                        const imageScale =
+                        const className = this._subtitleClasses(subtitle.track);
+                        const widthRatio =
                             ((this.subtitleSettings?.imageBasedSubtitleScaleFactor ?? 1) *
-                                this.context.video.getBoundingClientRect().width) /
+                                subtitle.textImage.image.width) /
                             subtitle.textImage.screen.width;
-                        const width = imageScale * subtitle.textImage.image.width;
 
                         return `
                             <div data-track="${
                                 subtitle.track ?? 0
-                            }" style="max-width:${width}px;margin:auto;" class="${className}"}">
+                            }" data-asb-video-width-ratio="${widthRatio}" style="max-width:100%;margin:auto;" class="${className}">
                                 <img
                                     style="width:100%;"
                                     alt="subtitle"
@@ -785,11 +794,8 @@ export default class SubtitleController {
     }
 
     private _subtitleClasses(track?: number) {
-        if (track === undefined || this.subtitleClasses === undefined) {
-            return '';
-        }
-
-        return this.subtitleClasses[track] ?? this.subtitleClasses;
+        if (track === undefined || this.subtitleClasses === undefined) return '';
+        return this.subtitleClasses[track] ?? this.subtitleClasses[0] ?? '';
     }
 
     private _subtitleStyles(track?: number) {

--- a/extension/src/entrypoints/video.content/video.css
+++ b/extension/src/entrypoints/video.content/video.css
@@ -30,7 +30,9 @@
    size inheriting from the subtitle so the host page's element styles can't
    resize them. */
 .asbplayer-subtitles > span span,
-.asbplayer-subtitles > span ruby {
+.asbplayer-subtitles > span ruby,
+.asbplayer-fullscreen-subtitles > span span,
+.asbplayer-fullscreen-subtitles > span ruby {
     font-size: inherit !important;
 }
 
@@ -101,11 +103,7 @@
 .asbplayer-fullscreen-subtitles {
     text-align: center !important;
     color: white;
-    text-shadow:
-        0 0 2px black,
-        0 0 2px black,
-        0 0 2px black,
-        0 0 2px black;
+    text-shadow: none;
     font-size: 36px;
     padding-left: 10px;
     padding-right: 10px;

--- a/extension/src/entrypoints/video.content/video.css
+++ b/extension/src/entrypoints/video.content/video.css
@@ -14,10 +14,18 @@
     pointer-events: auto !important;
 }
 
-.asbplayer-subtitles {
+.asbplayer-subtitles,
+.asbplayer-fullscreen-subtitles {
     text-align: center !important;
     color: white;
-    font-size: 24px;
+    text-shadow: none;
+    font-family: sans-serif;
+    font-size: 36px;
+    font-style: normal;
+    font-stretch: normal;
+    font-variant: normal;
+    letter-spacing: normal;
+    text-transform: none;
     padding-left: 10px;
     padding-right: 10px;
     user-select: text !important;
@@ -98,19 +106,6 @@
     white-space: pre-wrap !important;
     user-select: none;
     pointer-events: none;
-}
-
-.asbplayer-fullscreen-subtitles {
-    text-align: center !important;
-    color: white;
-    text-shadow: none;
-    font-size: 36px;
-    padding-left: 10px;
-    padding-right: 10px;
-    user-select: text !important;
-    cursor: text !important;
-    line-height: normal !important;
-    white-space: pre-wrap !important;
 }
 
 .asb-reading {

--- a/extension/src/services/element-overlay.test.ts
+++ b/extension/src/services/element-overlay.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { CachingElementOverlay, OffsetAnchor } from '@project/extension/src/services/element-overlay';
+
+describe('CachingElementOverlay fullscreen transitions', () => {
+    let fullscreenElement: Element | null;
+
+    beforeEach(() => {
+        fullscreenElement = null;
+        Object.defineProperty(document, 'fullscreenElement', {
+            configurable: true,
+            get: () => fullscreenElement,
+        });
+    });
+
+    afterEach(() => {
+        document.body.replaceChildren();
+        delete (document as unknown as { fullscreenElement?: Element | null }).fullscreenElement;
+    });
+
+    it('updates the class of every subtitle when moving into and out of fullscreen', () => {
+        const targetElement = document.createElement('video');
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        overlay.setHtml([
+            { key: 'one', html: () => '<span>one</span>' },
+            { key: 'two', html: () => '<span>two</span>' },
+        ]);
+        const nonFullscreenElements = [...document.querySelectorAll('.non-fullscreen-container > div')];
+        expect(nonFullscreenElements).toHaveLength(2);
+        expect(nonFullscreenElements.every((element) => element.className === 'non-fullscreen-content')).toBe(true);
+
+        fullscreenElement = document.documentElement;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        const fullscreenElements = [...document.querySelectorAll('.fullscreen-container > div')];
+        expect(fullscreenElements).toHaveLength(2);
+        expect(fullscreenElements.every((element) => element.className === 'fullscreen-content')).toBe(true);
+
+        fullscreenElement = null;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        const returnedElements = [...document.querySelectorAll('.non-fullscreen-container > div')];
+        expect(returnedElements).toHaveLength(2);
+        expect(returnedElements.every((element) => element.className === 'non-fullscreen-content')).toBe(true);
+
+        overlay.dispose();
+    });
+
+    it('does not apply subtitle content classes to structural line breaks during transitions', () => {
+        const targetElement = document.createElement('video');
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+        overlay.appendHtml('<span>offset</span>');
+
+        const lineBreak = document.querySelector('.non-fullscreen-container > br');
+        expect(lineBreak?.className).toBe('');
+
+        fullscreenElement = document.documentElement;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        expect(document.querySelector('.fullscreen-container > br')).toBe(lineBreak);
+        expect(lineBreak?.className).toBe('');
+        expect(
+            [...document.querySelectorAll('.fullscreen-container > div')].every(
+                (element) => element.className === 'fullscreen-content'
+            )
+        ).toBe(true);
+
+        fullscreenElement = null;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        expect(document.querySelector('.non-fullscreen-container > br')).toBe(lineBreak);
+        expect(lineBreak?.className).toBe('');
+
+        overlay.dispose();
+    });
+});

--- a/extension/src/services/element-overlay.test.ts
+++ b/extension/src/services/element-overlay.test.ts
@@ -192,6 +192,88 @@ describe('CachingElementOverlay fullscreen transitions', () => {
         }
     });
 
+    it('keeps top and bottom overlays inside the viewport when the video covers it', () => {
+        const originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () => ({ left: 0, top: -100, width: 1000, height: 800 }) as DOMRect;
+        const topOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'top-container',
+            nonFullscreenContentClassName: 'top-content',
+            fullscreenContainerClassName: 'fullscreen-top-container',
+            fullscreenContentClassName: 'fullscreen-top-content',
+            offsetAnchor: OffsetAnchor.top,
+            contentPositionOffset: 8,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        const bottomOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'bottom-container',
+            nonFullscreenContentClassName: 'bottom-content',
+            fullscreenContainerClassName: 'fullscreen-bottom-container',
+            fullscreenContentClassName: 'fullscreen-bottom-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            topOverlay.setHtml([{ key: 'top', html: () => '<span>top</span>' }]);
+            bottomOverlay.setHtml([{ key: 'bottom', html: () => '<span>bottom</span>' }]);
+
+            expect(document.querySelector<HTMLElement>('.top-container')?.style.top).toBe('8px');
+            expect(document.querySelector<HTMLElement>('.bottom-container')?.style.top).toBe('525px');
+        } finally {
+            topOverlay.dispose();
+            bottomOverlay.dispose();
+            if (originalInnerHeight) Object.defineProperty(window, 'innerHeight', originalInnerHeight);
+            else delete (window as unknown as { innerHeight?: number }).innerHeight;
+        }
+    });
+
+    it('does not pin overlays to the viewport when the video is completely outside it', () => {
+        const originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () => ({ left: 0, top: 700, width: 1000, height: 200 }) as DOMRect;
+        const topOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'top-container',
+            nonFullscreenContentClassName: 'top-content',
+            fullscreenContainerClassName: 'fullscreen-top-container',
+            fullscreenContentClassName: 'fullscreen-top-content',
+            offsetAnchor: OffsetAnchor.top,
+            contentPositionOffset: 8,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        const bottomOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'bottom-container',
+            nonFullscreenContentClassName: 'bottom-content',
+            fullscreenContainerClassName: 'fullscreen-bottom-container',
+            fullscreenContentClassName: 'fullscreen-bottom-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            topOverlay.setHtml([{ key: 'top', html: () => '<span>top</span>' }]);
+            bottomOverlay.setHtml([{ key: 'bottom', html: () => '<span>bottom</span>' }]);
+
+            expect(document.querySelector<HTMLElement>('.top-container')?.style.top).toBe('708px');
+            expect(document.querySelector<HTMLElement>('.bottom-container')?.style.top).toBe('825px');
+        } finally {
+            topOverlay.dispose();
+            bottomOverlay.dispose();
+            if (originalInnerHeight) Object.defineProperty(window, 'innerHeight', originalInnerHeight);
+            else delete (window as unknown as { innerHeight?: number }).innerHeight;
+        }
+    });
+
     it('keeps top and bottom overlays attached to the video while it scrolls above the viewport', () => {
         const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');
         let scrollY = 0;

--- a/extension/src/services/element-overlay.test.ts
+++ b/extension/src/services/element-overlay.test.ts
@@ -15,6 +15,7 @@ describe('CachingElementOverlay fullscreen transitions', () => {
     afterEach(() => {
         document.body.replaceChildren();
         delete (document as unknown as { fullscreenElement?: Element | null }).fullscreenElement;
+        delete (document as unknown as { elementFromPoint?: typeof document.elementFromPoint }).elementFromPoint;
     });
 
     it('updates the class of every subtitle when moving into and out of fullscreen', () => {
@@ -91,6 +92,339 @@ describe('CachingElementOverlay fullscreen transitions', () => {
         expect(document.querySelector('.non-fullscreen-container > br')).toBe(lineBreak);
         expect(lineBreak?.className).toBe('');
 
+        overlay.dispose();
+    });
+
+    it('positions the destination immediately in its fullscreen parent coordinate space', () => {
+        const fullscreenRoot = document.createElement('div');
+        const videoParent = document.createElement('div');
+        const targetElement = document.createElement('video');
+        fullscreenRoot.appendChild(videoParent);
+        videoParent.appendChild(targetElement);
+        document.body.appendChild(fullscreenRoot);
+
+        videoParent.getBoundingClientRect = () => ({ left: 100, top: 50, width: 800, height: 500 }) as DOMRect;
+        targetElement.getBoundingClientRect = () => ({ left: 140, top: 90, width: 600, height: 300 }) as DOMRect;
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => videoParent.lastElementChild,
+        });
+
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+        fullscreenElement = fullscreenRoot;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        const fullscreenContainer = videoParent.querySelector<HTMLElement>('.fullscreen-container');
+        expect(fullscreenContainer?.style.left).toBe('340px');
+        expect(fullscreenContainer?.style.top).toBe('265px');
+
+        overlay.dispose();
+    });
+
+    it('accounts for horizontal and vertical document scrolling outside fullscreen', () => {
+        const originalScrollX = Object.getOwnPropertyDescriptor(window, 'scrollX');
+        const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');
+        Object.defineProperty(window, 'scrollX', { configurable: true, value: 30 });
+        Object.defineProperty(window, 'scrollY', { configurable: true, value: 100 });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () => ({ left: 10, top: 20, width: 400, height: 200 }) as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+            const container = document.querySelector<HTMLElement>('.non-fullscreen-container');
+            expect(container?.style.left).toBe('240px');
+            expect(container?.style.top).toBe('245px');
+        } finally {
+            overlay.dispose();
+            if (originalScrollX) Object.defineProperty(window, 'scrollX', originalScrollX);
+            else delete (window as unknown as { scrollX?: number }).scrollX;
+            if (originalScrollY) Object.defineProperty(window, 'scrollY', originalScrollY);
+            else delete (window as unknown as { scrollY?: number }).scrollY;
+        }
+    });
+
+    it('anchors bottom subtitles to the video bottom when it is partially clipped', () => {
+        const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');
+        Object.defineProperty(window, 'scrollY', { configurable: true, value: 500 });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () => ({ left: 10, top: -100, width: 400, height: 360 }) as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+            expect(document.querySelector<HTMLElement>('.non-fullscreen-container')?.style.top).toBe('685px');
+        } finally {
+            overlay.dispose();
+            if (originalScrollY) Object.defineProperty(window, 'scrollY', originalScrollY);
+            else delete (window as unknown as { scrollY?: number }).scrollY;
+        }
+    });
+
+    it('keeps top and bottom overlays attached to the video while it scrolls above the viewport', () => {
+        const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');
+        let scrollY = 0;
+        Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollY });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () =>
+            ({ left: 10, top: 100 - scrollY, width: 400, height: 200 }) as DOMRect;
+        const topOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'top-container',
+            nonFullscreenContentClassName: 'top-content',
+            fullscreenContainerClassName: 'fullscreen-top-container',
+            fullscreenContentClassName: 'fullscreen-top-content',
+            offsetAnchor: OffsetAnchor.top,
+            contentPositionOffset: 8,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        const bottomOverlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'bottom-container',
+            nonFullscreenContentClassName: 'bottom-content',
+            fullscreenContainerClassName: 'fullscreen-bottom-container',
+            fullscreenContentClassName: 'fullscreen-bottom-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            topOverlay.setHtml([{ key: 'top', html: () => '<span>top</span>' }]);
+            bottomOverlay.setHtml([{ key: 'bottom', html: () => '<span>bottom</span>' }]);
+            const topContainer = document.querySelector<HTMLElement>('.top-container');
+            const bottomContainer = document.querySelector<HTMLElement>('.bottom-container');
+            expect(topContainer?.style.top).toBe('108px');
+            expect(bottomContainer?.style.top).toBe('225px');
+
+            scrollY = 400;
+            topOverlay.refresh();
+            bottomOverlay.refresh();
+
+            expect(topContainer?.style.top).toBe('108px');
+            expect(bottomContainer?.style.top).toBe('225px');
+        } finally {
+            topOverlay.dispose();
+            bottomOverlay.dispose();
+            if (originalScrollY) Object.defineProperty(window, 'scrollY', originalScrollY);
+            else delete (window as unknown as { scrollY?: number }).scrollY;
+        }
+    });
+
+    it('preserves the last valid layout while video geometry is transiently unavailable', () => {
+        const targetElement = document.createElement('video');
+        let rect = { left: 10, top: 20, width: 400, height: 200 };
+        targetElement.getBoundingClientRect = () => rect as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+        const container = document.querySelector<HTMLElement>('.non-fullscreen-container');
+        expect(container?.style.left).toBe('210px');
+        expect(container?.style.top).toBe('145px');
+
+        rect = { left: 0, top: 0, width: 0, height: 0 };
+        overlay.refresh();
+
+        expect(container?.style.left).toBe('210px');
+        expect(container?.style.top).toBe('145px');
+        overlay.dispose();
+    });
+
+    it('hides an overlay until valid video geometry is available', () => {
+        const targetElement = document.createElement('video');
+        let rect = { left: 0, top: 0, width: 0, height: 0 };
+        targetElement.getBoundingClientRect = () => rect as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+        const container = document.querySelector<HTMLElement>('.non-fullscreen-container');
+        expect(container?.style.getPropertyValue('visibility')).toBe('hidden');
+        expect(container?.style.getPropertyPriority('visibility')).toBe('important');
+
+        rect = { left: 10, top: 20, width: 400, height: 200 };
+        overlay.refresh();
+
+        expect(container?.style.visibility).toBe('');
+        expect(container?.style.left).toBe('210px');
+        expect(container?.style.top).toBe('145px');
+        overlay.dispose();
+    });
+
+    it('positions windowed subtitles in their actual containing block coordinate space', () => {
+        const originalOffsetParent = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
+        const originalBodyRect = document.body.getBoundingClientRect;
+        const originalBodyProperties = Object.fromEntries(
+            ['scrollLeft', 'scrollTop', 'clientLeft', 'clientTop'].map((property) => [
+                property,
+                Object.getOwnPropertyDescriptor(document.body, property),
+            ])
+        );
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+            configurable: true,
+            get() {
+                return this.classList.contains('non-fullscreen-container') ? document.body : null;
+            },
+        });
+        document.body.getBoundingClientRect = () => ({ left: 20, top: 40, width: 800, height: 600 }) as DOMRect;
+        Object.defineProperties(document.body, {
+            scrollLeft: { configurable: true, value: 5 },
+            scrollTop: { configurable: true, value: 7 },
+            clientLeft: { configurable: true, value: 2 },
+            clientTop: { configurable: true, value: 3 },
+        });
+        const targetElement = document.createElement('video');
+        targetElement.getBoundingClientRect = () => ({ left: 100, top: 100, width: 200, height: 100 }) as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        try {
+            overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+            const container = document.querySelector<HTMLElement>('.non-fullscreen-container');
+            expect(container?.style.left).toBe('183px');
+            expect(container?.style.top).toBe('89px');
+        } finally {
+            overlay.dispose();
+            document.body.getBoundingClientRect = originalBodyRect;
+            if (originalOffsetParent) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalOffsetParent);
+            } else {
+                delete (HTMLElement.prototype as unknown as { offsetParent?: Element | null }).offsetParent;
+            }
+            for (const [property, descriptor] of Object.entries(originalBodyProperties)) {
+                if (descriptor) Object.defineProperty(document.body, property, descriptor);
+                else delete (document.body as unknown as Record<string, unknown>)[property];
+            }
+        }
+    });
+
+    it('reparents the fullscreen container when the video moves to a new player subtree', () => {
+        const fullscreenRoot = document.createElement('div');
+        const firstParent = document.createElement('div');
+        const secondParent = document.createElement('div');
+        const targetElement = document.createElement('video');
+        fullscreenRoot.append(firstParent, secondParent);
+        firstParent.appendChild(targetElement);
+        document.body.appendChild(fullscreenRoot);
+        firstParent.getBoundingClientRect = secondParent.getBoundingClientRect = () =>
+            ({ left: 0, top: 0, width: 800, height: 500 }) as DOMRect;
+        targetElement.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 500 }) as DOMRect;
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => targetElement.parentElement?.lastElementChild ?? null,
+        });
+
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+        fullscreenElement = fullscreenRoot;
+        document.dispatchEvent(new Event('fullscreenchange'));
+        expect(firstParent.querySelector('.fullscreen-container')).not.toBeNull();
+
+        secondParent.appendChild(targetElement);
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        expect(firstParent.querySelector('.fullscreen-container')).toBeNull();
+        expect(secondParent.querySelector('.fullscreen-container')).not.toBeNull();
+
+        overlay.dispose();
+    });
+
+    it('resizes responsive cached content when the video width changes', () => {
+        const targetElement = document.createElement('video');
+        let videoWidth = 640;
+        targetElement.getBoundingClientRect = () => ({ left: 0, top: 0, width: videoWidth, height: 360 }) as DOMRect;
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+
+        overlay.setHtml([
+            {
+                key: 'image',
+                html: () => '<div data-asb-video-width-ratio="0.5"></div>',
+            },
+        ]);
+        const responsiveContent = document.querySelector<HTMLElement>('[data-asb-video-width-ratio]');
+        expect(responsiveContent?.style.width).toBe('320px');
+
+        videoWidth = 1280;
+        overlay.refresh();
+
+        expect(responsiveContent?.style.width).toBe('640px');
         overlay.dispose();
     });
 });

--- a/extension/src/services/element-overlay.ts
+++ b/extension/src/services/element-overlay.ts
@@ -194,12 +194,16 @@ export class CachingElementOverlay implements ElementOverlay {
         const toggle = () => {
             if (document.fullscreenElement) {
                 container.style.setProperty('display', 'none', 'important');
-                this._transferChildren(container, this._fullscreenContainerElement());
+                this._transferChildren(container, this._fullscreenContainerElement(), this.fullscreenContentClassName);
             } else {
                 container.style.display = '';
 
                 if (this.fullscreenContainerElement) {
-                    this._transferChildren(this.fullscreenContainerElement, container);
+                    this._transferChildren(
+                        this.fullscreenContainerElement,
+                        container,
+                        this.nonFullscreenContentClassName
+                    );
                 }
             }
         };
@@ -235,11 +239,19 @@ export class CachingElementOverlay implements ElementOverlay {
                 }
 
                 if (this.nonFullscreenContainerElement) {
-                    this._transferChildren(this.nonFullscreenContainerElement, container);
+                    this._transferChildren(
+                        this.nonFullscreenContainerElement,
+                        container,
+                        this.fullscreenContentClassName
+                    );
                 }
             } else if (!document.fullscreenElement) {
                 container.style.setProperty('display', 'none', 'important');
-                this._transferChildren(container, this._nonFullscreenContainerElement());
+                this._transferChildren(
+                    container,
+                    this._nonFullscreenContainerElement(),
+                    this.nonFullscreenContentClassName
+                );
             }
         };
 
@@ -291,12 +303,12 @@ export class CachingElementOverlay implements ElementOverlay {
         return document.body;
     }
 
-    private _transferChildren(source: HTMLElement, destination: HTMLElement) {
-        if (!source) {
-            return;
-        }
+    private _transferChildren(source: HTMLElement, destination: HTMLElement, contentClassName: string) {
+        if (!source || !destination) return;
+        if (source === destination) return;
 
         while (source.firstChild) {
+            if (source.firstChild instanceof HTMLDivElement) source.firstChild.className = contentClassName;
             destination.appendChild(source.firstChild);
         }
     }

--- a/extension/src/services/element-overlay.ts
+++ b/extension/src/services/element-overlay.ts
@@ -434,6 +434,8 @@ export class CachingElementOverlay implements ElementOverlay {
     private _refreshContainerStylesAfterLayout(container: HTMLElement, options: ApplyContainerStylesOptions) {
         this._applyContainerStyles(container, options);
         if (this.layoutAnimationFrame !== undefined) cancelAnimationFrame(this.layoutAnimationFrame);
+        // Page-owned fullscreenchange listeners may update the player after ours runs.
+        // Measure again after the event dispatch using the resulting DOM and styles.
         this.layoutAnimationFrame = requestAnimationFrame(() => {
             this.layoutAnimationFrame = undefined;
             if (container.isConnected) this._applyContainerStyles(container, options);
@@ -459,10 +461,14 @@ export class CachingElementOverlay implements ElementOverlay {
         container.style.removeProperty('visibility');
 
         let left = rect.left + rect.width / 2;
+        const videoBottom = rect.top + rect.height;
+        const videoIntersectsViewport = rect.top < window.innerHeight && videoBottom > 0;
+        const videoCoversViewport = rect.top < 0 && videoBottom > window.innerHeight;
         let top =
             this.offsetAnchor === OffsetAnchor.bottom
-                ? rect.top + rect.height - this.contentPositionOffset
-                : rect.top + this.contentPositionOffset;
+                ? (videoIntersectsViewport ? Math.min(videoBottom, window.innerHeight) : videoBottom) -
+                  this.contentPositionOffset
+                : (videoCoversViewport ? 0 : rect.top) + this.contentPositionOffset;
 
         const containingBlock =
             container.offsetParent instanceof HTMLElement

--- a/extension/src/services/element-overlay.ts
+++ b/extension/src/services/element-overlay.ts
@@ -41,6 +41,10 @@ export interface ElementOverlay {
     containerElement: HTMLElement | undefined;
 }
 
+interface ApplyContainerStylesOptions {
+    fullscreen: boolean;
+}
+
 export class CachingElementOverlay implements ElementOverlay {
     private readonly targetElement: HTMLElement;
 
@@ -55,6 +59,7 @@ export class CachingElementOverlay implements ElementOverlay {
     private fullscreenElementFullscreenChangeListener?: (this: any, event: Event) => any;
     private fullscreenElementFullscreenPollingInterval?: ReturnType<typeof setInterval>;
     private fullscreenStylesInterval?: ReturnType<typeof setInterval>;
+    private layoutAnimationFrame?: number;
     private onMouseOver: (event: MouseEvent) => void;
     private onMouseOut: (event: MouseEvent) => void;
     private onContainerStyles?: (container: HTMLElement) => void;
@@ -164,7 +169,9 @@ export class CachingElementOverlay implements ElementOverlay {
             contentElement.className = this.nonFullscreenContentClassName;
         }
 
-        this._setChildren(this._nonFullscreenContainerElement(), contentElements);
+        const container = this._nonFullscreenContainerElement();
+        this._setChildren(container, contentElements);
+        this._applyResponsiveContentStyles(container, this.targetElement.getBoundingClientRect().width);
     }
 
     private _displayFullscreenContentElementsWithHtml(htmls: KeyedHtml[]) {
@@ -176,7 +183,9 @@ export class CachingElementOverlay implements ElementOverlay {
             contentElement.className = this.fullscreenContentClassName;
         }
 
-        this._setChildren(this._fullscreenContainerElement(), contentElements);
+        const container = this._fullscreenContainerElement();
+        this._setChildren(container, contentElements);
+        this._applyResponsiveContentStyles(container, this.targetElement.getBoundingClientRect().width);
     }
 
     private _nonFullscreenContainerElement() {
@@ -188,13 +197,16 @@ export class CachingElementOverlay implements ElementOverlay {
         container.className = this.nonFullscreenContainerClassName;
         container.onmouseover = this.onMouseOver;
         container.onmouseout = this.onMouseOut;
-        this._applyContainerStyles(container);
         document.body.appendChild(container);
+        this._applyContainerStyles(container, { fullscreen: false });
 
         const toggle = () => {
             if (document.fullscreenElement) {
                 container.style.setProperty('display', 'none', 'important');
                 this._transferChildren(container, this._fullscreenContainerElement(), this.fullscreenContentClassName);
+                if (this.fullscreenContainerElement) {
+                    this._refreshContainerStylesAfterLayout(this.fullscreenContainerElement, { fullscreen: true });
+                }
             } else {
                 container.style.display = '';
 
@@ -205,12 +217,16 @@ export class CachingElementOverlay implements ElementOverlay {
                         this.nonFullscreenContentClassName
                     );
                 }
+                this._refreshContainerStylesAfterLayout(container, { fullscreen: false });
             }
         };
 
         toggle();
         this.nonFullscreenElementFullscreenChangeListener = () => toggle();
-        this.nonFullscreenStylesInterval = setInterval(() => this._applyContainerStyles(container), 1000);
+        this.nonFullscreenStylesInterval = setInterval(
+            () => this._applyContainerStyles(container, { fullscreen: false }),
+            1000
+        );
         this.nonFullscreenElementFullscreenPollingInterval = setInterval(() => toggle(), 1000);
         document.addEventListener('fullscreenchange', this.nonFullscreenElementFullscreenChangeListener);
         this.nonFullscreenContainerElement = container;
@@ -226,16 +242,17 @@ export class CachingElementOverlay implements ElementOverlay {
         container.className = this.fullscreenContainerClassName;
         container.onmouseover = this.onMouseOver;
         container.onmouseout = this.onMouseOut;
-        this._applyContainerStyles(container);
         this._findFullscreenParentElement(container).appendChild(container);
+        this._applyContainerStyles(container, { fullscreen: true });
         container.style.setProperty('display', 'none', 'important');
 
         const toggle = () => {
             if (document.fullscreenElement) {
-                if (container.style.display === 'none') {
+                if (container.style.display === 'none' || this._fullscreenContainerParentIsStale(container)) {
                     container.style.display = '';
                     container.remove();
                     this._findFullscreenParentElement(container).appendChild(container);
+                    this._refreshContainerStylesAfterLayout(container, { fullscreen: true });
                 }
 
                 if (this.nonFullscreenContainerElement) {
@@ -252,12 +269,20 @@ export class CachingElementOverlay implements ElementOverlay {
                     this._nonFullscreenContainerElement(),
                     this.nonFullscreenContentClassName
                 );
+                if (this.nonFullscreenContainerElement) {
+                    this._refreshContainerStylesAfterLayout(this.nonFullscreenContainerElement, {
+                        fullscreen: false,
+                    });
+                }
             }
         };
 
         toggle();
         this.fullscreenElementFullscreenChangeListener = () => toggle();
-        this.fullscreenStylesInterval = setInterval(() => this._applyContainerStyles(container), 1000);
+        this.fullscreenStylesInterval = setInterval(
+            () => this._applyContainerStyles(container, { fullscreen: true }),
+            1000
+        );
         this.fullscreenElementFullscreenPollingInterval = setInterval(() => toggle(), 1000);
         document.addEventListener('fullscreenchange', this.fullscreenElementFullscreenChangeListener);
         this.fullscreenContainerElement = container;
@@ -313,6 +338,11 @@ export class CachingElementOverlay implements ElementOverlay {
         }
     }
 
+    private _fullscreenContainerParentIsStale(container: HTMLElement) {
+        const parent = container.parentElement;
+        return !container.isConnected || parent === null || !parent.contains(this.targetElement);
+    }
+
     private _setChildren(containerElement: HTMLElement, contentElements: HTMLElement[]) {
         while (containerElement.firstChild) {
             this.domCache.return(containerElement.lastChild! as HTMLElement);
@@ -355,11 +385,11 @@ export class CachingElementOverlay implements ElementOverlay {
 
     refresh() {
         if (this.fullscreenContainerElement) {
-            this._applyContainerStyles(this.fullscreenContainerElement);
+            this._applyContainerStyles(this.fullscreenContainerElement, { fullscreen: true });
         }
 
         if (this.nonFullscreenContainerElement) {
-            this._applyContainerStyles(this.nonFullscreenContainerElement);
+            this._applyContainerStyles(this.nonFullscreenContainerElement, { fullscreen: false });
         }
     }
 
@@ -388,6 +418,11 @@ export class CachingElementOverlay implements ElementOverlay {
             clearInterval(this.fullscreenElementFullscreenPollingInterval);
         }
 
+        if (this.layoutAnimationFrame !== undefined) {
+            cancelAnimationFrame(this.layoutAnimationFrame);
+            this.layoutAnimationFrame = undefined;
+        }
+
         this.defaultContentElement?.remove();
         this.defaultContentElement = undefined;
         this.nonFullscreenContainerElement?.remove();
@@ -396,9 +431,56 @@ export class CachingElementOverlay implements ElementOverlay {
         this.fullscreenContainerElement = undefined;
     }
 
-    private _applyContainerStyles(container: HTMLElement) {
+    private _refreshContainerStylesAfterLayout(container: HTMLElement, options: ApplyContainerStylesOptions) {
+        this._applyContainerStyles(container, options);
+        if (this.layoutAnimationFrame !== undefined) cancelAnimationFrame(this.layoutAnimationFrame);
+        this.layoutAnimationFrame = requestAnimationFrame(() => {
+            this.layoutAnimationFrame = undefined;
+            if (container.isConnected) this._applyContainerStyles(container, options);
+        });
+    }
+
+    private _applyContainerStyles(container: HTMLElement, { fullscreen }: ApplyContainerStylesOptions) {
         const rect = this.targetElement.getBoundingClientRect();
-        container.style.left = rect.left + rect.width / 2 + 'px';
+        if (
+            !Number.isFinite(rect.left) ||
+            !Number.isFinite(rect.top) ||
+            !Number.isFinite(rect.width) ||
+            !Number.isFinite(rect.height) ||
+            rect.width <= 0 ||
+            rect.height <= 0
+        ) {
+            if (container.style.left === '' || container.style.top === '') {
+                container.style.setProperty('visibility', 'hidden', 'important');
+            }
+            return;
+        }
+
+        container.style.removeProperty('visibility');
+
+        let left = rect.left + rect.width / 2;
+        let top =
+            this.offsetAnchor === OffsetAnchor.bottom
+                ? rect.top + rect.height - this.contentPositionOffset
+                : rect.top + this.contentPositionOffset;
+
+        const containingBlock =
+            container.offsetParent instanceof HTMLElement
+                ? container.offsetParent
+                : fullscreen
+                  ? container.parentElement
+                  : null;
+        if (containingBlock) {
+            const containingBlockRect = containingBlock.getBoundingClientRect();
+            left += containingBlock.scrollLeft - containingBlock.clientLeft - containingBlockRect.left;
+            top += containingBlock.scrollTop - containingBlock.clientTop - containingBlockRect.top;
+        } else {
+            left += window.scrollX;
+            top += window.scrollY;
+        }
+
+        container.style.left = left + 'px';
+        this._applyResponsiveContentStyles(container, rect.width);
 
         if (this.contentWidthPercentage === -1) {
             container.style.maxWidth = rect.width + 'px';
@@ -409,18 +491,17 @@ export class CachingElementOverlay implements ElementOverlay {
                 Math.min(window.innerWidth, (rect.width * this.contentWidthPercentage) / 100) + 'px';
         }
 
-        const clampedY = Math.max(rect.top + window.scrollY, 0);
-
-        if (this.offsetAnchor === OffsetAnchor.bottom) {
-            const clampedHeight = Math.min(clampedY + rect.height, window.innerHeight + window.scrollY);
-            container.style.top = clampedHeight - this.contentPositionOffset + 'px';
-            container.style.bottom = '';
-        } else {
-            container.style.top = clampedY + this.contentPositionOffset + 'px';
-            container.style.bottom = '';
-        }
+        container.style.top = top + 'px';
+        container.style.bottom = '';
 
         this.onContainerStyles?.(container);
+    }
+
+    private _applyResponsiveContentStyles(container: HTMLElement, videoWidth: number) {
+        for (const element of container.querySelectorAll<HTMLElement>('[data-asb-video-width-ratio]')) {
+            const ratio = Number(element.dataset.asbVideoWidthRatio);
+            if (Number.isFinite(ratio)) element.style.width = `${videoWidth * ratio}px`;
+        }
     }
 
     private _clickable(rootNode: Document | ShadowRoot, container: HTMLElement, element: HTMLElement): boolean {


### PR DESCRIPTION
[This was reported in discord.](https://discord.com/channels/962412001810849814/962425139058868234/1539273945356836874)

- The fullscreen subtitle class had a default text shadow that the non-fullscreen didn't have
- The transition between fullscreen and non-fullscreen didn't properly update all the classes
- This means that when subtitles were updated (e.g new annotation data), depending if the user was currently fullscreen or not the subtitle appearance would behave differently
- We will now also set explicit defaults for the outline thickness so that user settings are always applied if they want transparency

The first commit fixed the above issue, the second commit fixes some other inconsistencies with fullscreen subtitles. This speculatively closes #432 and closes #668.
- Rerender subtitles when more of its relevant inputs change
- Image width cache could be stale so we store the ratio and perform the final calculation when needed
- Consistent fallbacks for missing settings or track data
- Ensure subtitles are rerendered immediately when a change is needed rather than wait for the interval
- Consistent css defaults between fullscreen and non fullscreen subtitles
- Account for relative offsets such as scrolling or the video changing

I tested the behaviors of subtitles in fullscreen and non fullscreen modes across Chrome and Firefox and found no issues. It handling various resizing, scrolling, window resizing, fullscreen transitions, zooming, embeded videos, etc all with no issues. I did catch a couple in my testing so I may have missed some interactions.

---

The third commit fixes an unrelated issue I just ran into but seems to fit well with this PR. Chrome apparently sometimes strips newlines when they are by themselves between spans. I noticed that `VideoPlayer` no longer had any newlines when annotations were enabled and this was due to the table css being used for the subtitles. I changed it to `inline-block` which doesn't have this issue but it's kind of unbelievable it just started happening (multiple of my devices but not all). This wasn't always the case and downgrading asbplayer all the way to 1.17 did nothing and older chrome browsers still had the issue.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
