### PR TITLE
Netflix order simultaneous IMSC cues by vertical region position

### DIFF
--- a/common/subtitle-reader/subtitle-reader.test.ts
+++ b/common/subtitle-reader/subtitle-reader.test.ts
@@ -74,6 +74,39 @@ describe('SubtitleReader Netflix IMSC parsing', () => {
         expect(subtitles[2]).toMatchObject({ start: 7000, end: 9000, text: 'Third line' });
     });
 
+    it('orders simultaneous Netflix IMSC cues by their vertical region position', async () => {
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+            '<head><layout>' +
+            '<region xml:id="bottom" tts:origin="17.5% 84.62%"/>' +
+            '<region xml:id="top" tts:origin="30% 79.29%"/>' +
+            '</layout></head>' +
+            '<body><div>' +
+            '<p begin="385807505t" end="411245000t" region="bottom">I couldn\'t close it, so...</p>' +
+            '<p begin="385807505t" end="411245000t" region="top">Oh, I told you.</p>' +
+            '</div></body>' +
+            '</tt>';
+
+        const subtitles = await parse(xml);
+
+        expect(subtitles.map(({ text }) => text)).toEqual(['Oh, I told you.', "I couldn't close it, so..."]);
+    });
+
+    it('retains source order when a simultaneous Netflix IMSC cue has no usable region position', async () => {
+        const xml =
+            '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000">' +
+            '<head><layout><region xml:id="top" tts:origin="30% 79.29%"/></layout></head>' +
+            '<body><div>' +
+            '<p begin="10000000t" end="30000000t">First in source</p>' +
+            '<p begin="10000000t" end="30000000t" region="top">Second in source</p>' +
+            '</div></body>' +
+            '</tt>';
+
+        const subtitles = await parse(xml);
+
+        expect(subtitles.map(({ text }) => text)).toEqual(['First in source', 'Second in source']);
+    });
+
     it('converts IMSC ruby styles through the Netflix ruby tokenization', async () => {
         // The ruby container references two styles ("plain container") to exercise
         // multi-id style resolution.

--- a/common/subtitle-reader/subtitle-reader.ts
+++ b/common/subtitle-reader/subtitle-reader.ts
@@ -575,10 +575,24 @@ export default class SubtitleReader {
             return undefined;
         };
 
-        const subtitles: SubtitleNode[] = [];
+        const subtitles: { node: SubtitleNode; regionY?: number; sourceIndex: number }[] = [];
+
+        const regionYById = new Map<string, number>();
+        const percentageOriginRegex = /^\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)%\s+(?<y>[+-]?(?:\d+(?:\.\d*)?|\.\d+))%\s*$/;
+
+        for (const region of Array.from(doc.getElementsByTagNameNS('*', 'region'))) {
+            const id =
+                region.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'id') ?? region.getAttribute('xml:id');
+            const origin = region.getAttributeNS(stylingNamespace, 'origin') ?? region.getAttribute('tts:origin');
+            const match = origin === null ? null : percentageOriginRegex.exec(origin);
+            if (id !== null && match !== null) {
+                const regionY = Number(match.groups!.y);
+                if (Number.isFinite(regionY)) regionYById.set(id, regionY);
+            }
+        }
 
         // Collect every <p> regardless of how many <div>s the body splits them across.
-        for (const paragraph of Array.from(doc.getElementsByTagNameNS('*', 'p'))) {
+        for (const [sourceIndex, paragraph] of Array.from(doc.getElementsByTagNameNS('*', 'p')).entries()) {
             const begin = paragraph.getAttribute('begin');
             const end = paragraph.getAttribute('end');
             const dur = paragraph.getAttribute('dur');
@@ -598,15 +612,38 @@ export default class SubtitleReader {
                 continue;
             }
 
+            const regionId = paragraph.getAttribute('region');
             subtitles.push({
-                start,
-                end: stop,
-                text: this._filterText(this._imscParagraphText(paragraph, rubyRoleOf)),
-                track,
+                node: {
+                    start,
+                    end: stop,
+                    text: this._filterText(this._imscParagraphText(paragraph, rubyRoleOf)),
+                    track,
+                },
+                regionY: regionId === null ? undefined : regionYById.get(regionId),
+                sourceIndex,
             });
         }
 
-        return subtitles;
+        subtitles.sort((a, b) => a.node.start - b.node.start || a.sourceIndex - b.sourceIndex);
+
+        // Netflix sometimes authors simultaneous lines in bottom-to-top XML order. The
+        // region's vertical origin captures their intended visual reading order. Only use
+        // it when every cue in the group has a position; otherwise retain source order.
+        for (let start = 0; start < subtitles.length; ) {
+            let end = start + 1;
+            while (end < subtitles.length && subtitles[end].node.start === subtitles[start].node.start) {
+                ++end;
+            }
+            const group = subtitles.slice(start, end);
+            if (group.length > 1 && group.every((subtitle) => subtitle.regionY !== undefined)) {
+                group.sort((a, b) => a.regionY! - b.regionY! || a.sourceIndex - b.sourceIndex);
+                subtitles.splice(start, group.length, ...group);
+            }
+            start = end;
+        }
+
+        return subtitles.map(({ node }) => node);
     }
 
     // Flattens an IMSC <p> to text. Furigana renders inline as base(reading)


### PR DESCRIPTION
fixes #1136

The previous solution for this worked but in some cases the order Netflix sends the subtitles are incorrect. In these cases, we will use the positioning of the subtitles where the line above comes before the ones below when the times are the same. This uses the `tts:origin x y` which is a part of the TTML spec.

Using a regex for this best manages accuracy and safety without bloating the code.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
