### PR TITLE
Split leading/trailing punctuation from scanning-parser tokens

### DIFF
--- a/common/yomitan/yomitan.test.ts
+++ b/common/yomitan/yomitan.test.ts
@@ -389,6 +389,126 @@ describe('Yomitan', () => {
         await expect(yomitan.tokenizeBulk(['empty-group'])).resolves.toEqual([]);
     });
 
+    it('splits leading and trailing punctuation and whitespace from scanning-parser tokens that contain letters', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [
+                    [makeTokenPart({ text: ' \t「alpha!?」  ', reading: 'alpha' })],
+                    [makeTokenPart({ text: 'in-side', reading: 'in-side' })],
+                    [makeTokenPart({ text: '!?', reading: '' })],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenize(' \t「alpha!?」  in-side!?')).resolves.toEqual([
+            [{ text: ' ', reading: '' }],
+            [{ text: '\t', reading: '' }],
+            [{ text: '「', reading: '' }],
+            [{ text: 'alpha', reading: 'alpha' }],
+            [{ text: '!', reading: '' }],
+            [{ text: '?', reading: '' }],
+            [{ text: '」', reading: '' }],
+            [{ text: ' ', reading: '' }],
+            [{ text: ' ', reading: '' }],
+            [{ text: 'in-side', reading: 'in-side' }],
+            [{ text: '!?', reading: '' }],
+        ]);
+    });
+
+    it('clips a multipart scanning-parser token to the separator-free range', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: [
+                    [
+                        makeTokenPart({ text: ' ', reading: '' }),
+                        makeTokenPart({
+                            text: '「al',
+                            reading: 'al',
+                            headwords: [
+                                [
+                                    makeHeadword({
+                                        term: 'alpha',
+                                        reading: 'alpha',
+                                        sources: [makeSource({ originalText: 'alpha', deinflectedText: 'alpha' })],
+                                    }),
+                                ],
+                            ],
+                        }),
+                        makeTokenPart({ text: 'ph', reading: 'ph' }),
+                        makeTokenPart({ text: 'a」', reading: 'a' }),
+                        makeTokenPart({ text: '\t', reading: '' }),
+                    ],
+                ],
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenize(' 「alpha」\t')).resolves.toEqual([
+            [{ text: ' ', reading: '' }],
+            [{ text: '「', reading: '' }],
+            [
+                { text: 'al', reading: 'al' },
+                { text: 'ph', reading: 'ph' },
+                { text: 'a', reading: 'a' },
+            ],
+            [{ text: '」', reading: '' }],
+            [{ text: '\t', reading: '' }],
+        ]);
+        await expect(yomitan.lemmatize('alpha')).resolves.toEqual(['alpha']);
+        expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not split non-punctuation Unicode characters merely because they are not letters', async () => {
+        const fetcher = new MockFetcher();
+        const tokenTexts = ['5alpha5', '$alpha$', '+alpha=', '🙂alpha🙂', 'e\u0301'];
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: tokenTexts.map((text) => [makeTokenPart({ text, reading: text })]),
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenize(tokenTexts.join(''))).resolves.toEqual(
+            tokenTexts.map((text) => [{ text, reading: text }])
+        );
+    });
+
+    it('keeps whitespace and punctuation inside real-world words and phrases attached', async () => {
+        const fetcher = new MockFetcher();
+        const tokenTexts = ['New York', "can't", 'mother-in-law', 'example.com', 'rock ’n’ roll', 'l·l'];
+        fetcher.fetch.mockResolvedValueOnce([
+            makeTokenizeResult({
+                content: tokenTexts.map((text) => [makeTokenPart({ text, reading: text })]),
+            }),
+        ]);
+        const yomitan = new Yomitan(testDictionaryTrack(), fetcher);
+
+        await expect(yomitan.tokenize(tokenTexts.join(''))).resolves.toEqual(
+            tokenTexts.map((text) => [{ text, reading: text }])
+        );
+    });
+
+    it('leaves punctuation attached for mecab tokens', async () => {
+        const fetcher = new MockFetcher();
+        fetcher.fetch
+            .mockResolvedValueOnce({ version: '26.4.6' })
+            .mockResolvedValueOnce([makeMecabSupportResult()])
+            .mockResolvedValueOnce([
+                makeTokenizeResult({
+                    source: 'mecab',
+                    dictionary: 'UniDic 202402',
+                    content: [[makeTokenPart({ text: '「alpha」', reading: 'alpha' })]],
+                }),
+            ]);
+        const yomitan = new Yomitan(testDictionaryTrack({ dictionaryYomitanParser: 'mecab' }), fetcher);
+
+        await yomitan.version();
+        await expect(yomitan.tokenize('「alpha」')).resolves.toEqual([[{ text: '「alpha」', reading: 'alpha' }]]);
+    });
+
     it('returns an empty array without fetching in tokenizeBulk for 0 items', async () => {
         const fetcher = new MockFetcher();
         const yomitan = new Yomitan(testDictionaryTrack(), fetcher);

--- a/common/yomitan/yomitan.ts
+++ b/common/yomitan/yomitan.ts
@@ -23,6 +23,8 @@ const FREQUENCY_MODE_INFERENCE_GROUP_SIZE = 10;
 const FREQUENCY_MODE_INFERENCE_RANK_BASED_MATCHES = 7;
 
 const YEAR_MONTH_REGEX = /(?<year>20\d{2})(?<month>[01]\d)/;
+const LEADING_TOKEN_SEPARATOR_REGEX = /^[\p{P}\s]+/u;
+const TRAILING_TOKEN_SEPARATOR_REGEX = /[\p{P}\s]+$/u;
 
 export interface TokenPart {
     text: string;
@@ -110,6 +112,38 @@ export const splitTextForTokenization = (text: string) =>
         .split(STERM_AND_NEWLINES_REGEX)
         .map((part) => part.trim())
         .filter((part) => HAS_LETTER_REGEX.test(part));
+
+const splitTokenSeparators = (tokenParts: TokenPartResult[], tokenText: string): TokenPartResult[][] => {
+    const leadingSeparators = tokenText.match(LEADING_TOKEN_SEPARATOR_REGEX)?.[0] ?? '';
+    if (leadingSeparators.length === tokenText.length) return [tokenParts];
+
+    const trailingSeparators = tokenText.match(TRAILING_TOKEN_SEPARATOR_REGEX)?.[0] ?? '';
+    if (!leadingSeparators && !trailingSeparators) return [tokenParts];
+    if (!HAS_LETTER_REGEX.test(tokenText)) return [tokenParts];
+
+    const coreStart = leadingSeparators.length;
+    const coreEnd = tokenText.length - trailingSeparators.length;
+    const coreParts: TokenPartResult[] = [];
+    let partStart = 0;
+    for (const part of tokenParts) {
+        const partEnd = partStart + part.text.length;
+        const start = Math.max(coreStart, partStart);
+        const end = Math.min(coreEnd, partEnd);
+        if (start < end) {
+            coreParts.push({
+                ...part,
+                text: part.text.slice(start - partStart, end - partStart),
+            });
+        }
+        partStart = partEnd;
+    }
+
+    return [
+        ...Array.from(leadingSeparators, (text) => [{ text, reading: '' }]),
+        coreParts,
+        ...Array.from(trailingSeparators, (text) => [{ text, reading: '' }]),
+    ];
+};
 
 export function filterYomitanDictionaries(
     tokenizeResults: TokenizeResult[],
@@ -374,11 +408,11 @@ export class Yomitan {
         newlines: { text: string; index: number }[]
     ): void {
         let currIndex = 0;
-        for (const tokenParts of tokenizeResult.content) {
-            const tokenPart = tokenParts[0];
+        for (const originalTokenParts of tokenizeResult.content) {
+            const tokenPart = originalTokenParts[0];
             if (!tokenPart) continue;
 
-            const tokenText = tokenParts.map((p) => p.text).join('');
+            const tokenText = originalTokenParts.map((p) => p.text).join('');
             currIndex += tokenText.length;
             while (newlines.length && newlines[0].index < currIndex) {
                 const { text } = newlines.shift()!;
@@ -386,16 +420,25 @@ export class Yomitan {
                 tokensForText.push([{ text, reading: '' }]);
                 currIndex += text.length;
             }
-            tokensForText.push(tokenParts.map((p) => ({ text: p.text, reading: p.reading })));
-            const token = tokenText.trim();
+            const splitTokenParts =
+                this.dt.dictionaryYomitanParser === 'scanning-parser'
+                    ? splitTokenSeparators(originalTokenParts, tokenText)
+                    : [originalTokenParts];
+            for (const tokenParts of splitTokenParts) {
+                tokensForText.push(tokenParts.map((p) => ({ text: p.text, reading: p.reading })));
+                const currentTokenText =
+                    tokenParts === originalTokenParts ? tokenText : tokenParts.map((p) => p.text).join('');
+                const token = currentTokenText.trim();
+                const tokenPart = tokenParts[0];
 
-            if (!this.lemmatizeCache.has(token)) this.extractLemmaFromMecab(token, tokenPart);
+                if (!this.lemmatizeCache.has(token)) this.extractLemmaFromMecab(token, tokenPart);
 
-            const headwords = tokenPart.headwords;
-            if (headwords) {
-                if (!this.lemmatizeCache.has(token)) this.extractLemmas(token, headwords);
-                if (!this.frequencyCache.has(token)) this.extractFrequencyFromTokenize(token, headwords);
-                if (!this.pitchAccentCache.has(token)) this.extractPitchAccentFromTokenize(token, headwords);
+                const headwords = tokenPart.headwords;
+                if (headwords) {
+                    if (!this.lemmatizeCache.has(token)) this.extractLemmas(token, headwords);
+                    if (!this.frequencyCache.has(token)) this.extractFrequencyFromTokenize(token, headwords);
+                    if (!this.pitchAccentCache.has(token)) this.extractPitchAccentFromTokenize(token, headwords);
+                }
             }
         }
         while (newlines.length) {


### PR DESCRIPTION
This was reported twice in discord, one for Japanese and one for German so we can safely assume this is generic to the parser. The issue is that tokens are sometimes `word,` instead of `word` `,`. I'm not sure if it's a bug in Yomitan at runtime, when importing dictionaries, or even malformed dictionaries.

The fix on our end is simple and safe so I think it's the best solution. We will treat leading and trailing punctuation/whitespace on tokens as their own tokens. This should have no ill effects on any languages.

Edit:

The most likely reason for this is that the word doesn't exist in the user's dictionary and so Yomitan puts all the ungrouped characters together. So `noentry,` retains the comma as it looks no different from `notaword,`.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6