### PR TITLE
Bind picker only once on document ready

### DIFF
--- a/extension/src/controllers/video-data-sync-controller.ts
+++ b/extension/src/controllers/video-data-sync-controller.ts
@@ -137,6 +137,7 @@ export default class VideoDataSyncController {
         this._refreshingOpenPicker = false;
         this._cleanupPlayBlocker();
         this._openedLocation = undefined;
+        this._frame.unbind();
     }
 
     updateSettings({ streamingAutoSync, streamingLastLanguagesSynced }: AsbplayerSettings) {

--- a/extension/src/entrypoints/video.content/index.ts
+++ b/extension/src/entrypoints/video.content/index.ts
@@ -295,14 +295,14 @@ export default defineContentScript({
             });
         };
 
-        if (document.readyState === 'complete') {
-            bind().catch((error) => asbError('video', error));
-        } else {
-            document.addEventListener('readystatechange', () => {
-                if (document.readyState === 'complete') {
-                    bind().catch((error) => asbError('video', error));
-                }
-            });
-        }
+        let bindingStarted = false;
+        const bindOnceDocumentComplete = () => {
+            if (bindingStarted || document.readyState !== 'complete') return;
+            bindingStarted = true;
+            document.removeEventListener('readystatechange', bindOnceDocumentComplete);
+            void bind().catch((error) => asbError('video', error));
+        };
+        bindOnceDocumentComplete();
+        if (!bindingStarted) document.addEventListener('readystatechange', bindOnceDocumentComplete);
     },
 });


### PR DESCRIPTION
fixes #1159

The website in the issue had `readyState === 'complete'` 3 times instead of the normal one. So the simplest fix is to only bind on the first one. A simpler change would be:

```ts
const startBinding = () => {
    void bind().catch((error) => asbError('video', error));
};
if (document.readyState === 'complete') {
    startBinding();
} else {
    window.addEventListener('load', startBinding, { once: true });
}
```

but this required listening to `load` instead of `readyState` which could cause a regression somewhere.

Unrelated to the issue, we now call `this._frame.unbind()` in `unbind()` for `VideoDataSyncController` which seems like a mistake.

- [X] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
