### PR TITLE
Calculate generic parser subtitle labels using language codes

### DIFF
--- a/extension/src/pages/aggressive-generic-page.test.ts
+++ b/extension/src/pages/aggressive-generic-page.test.ts
@@ -82,7 +82,7 @@ it('discovers contextual subtitle metadata observed through JSON.parse', async (
         await expect(discovery.videoData(video)).resolves.toMatchObject({
             subtitles: [
                 {
-                    label: 'Japanese',
+                    label: '日本語',
                     language: 'ja',
                     url: 'http://localhost/captions/ja.vtt',
                     extension: 'vtt',
@@ -282,7 +282,7 @@ it('uses one bounded aggressive pass for a large late hydration payload', async 
         await expect(discovery.videoData(video)).resolves.toMatchObject({
             subtitles: [
                 {
-                    label: 'eng-us',
+                    label: 'English (United States)',
                     language: 'eng-us',
                     url: 'https://cdn.example/timedtext?id=1',
                     extension: 'vtt',
@@ -406,7 +406,7 @@ it('follows a subtitle metadata reference once and applies response URL context'
         const expected = {
             subtitles: [
                 {
-                    label: 'es',
+                    label: 'Español',
                     language: 'es',
                     url: 'https://example.com/captions/es.vtt',
                     extension: 'vtt',
@@ -1291,7 +1291,7 @@ it('discovers extensionless DASH subtitles using representation MIME metadata', 
         await expect(discovery.videoData(video)).resolves.toMatchObject({
             subtitles: [
                 {
-                    label: 'en',
+                    label: 'English',
                     language: 'en',
                     extension: 'ttml2',
                     url: ['https://cdn.example/media/captions?id=en'],

--- a/extension/src/pages/aggressive-generic-page.ts
+++ b/extension/src/pages/aggressive-generic-page.ts
@@ -22,6 +22,7 @@ import {
     bindVideoDataDiscovery,
     deduplicateTracks,
     detectedSubtitleLabel,
+    genericSubtitleDisplayLabel,
     hasSubtitleMetadataHint,
     isJsonContentType,
     normalizedContentType,
@@ -455,7 +456,7 @@ function requestUrl(input: RequestInfo | URL) {
 
 function dashTrack(
     playlist: Playlist,
-    language: string,
+    lang: string,
     metadata?: MpdTrackMetadata
 ): VideoDataSubtitleTrackDef | undefined {
     const urls = playlist.segments
@@ -470,7 +471,13 @@ function dashTrack(
         (metadata?.mimeType?.includes('ttml') === true ? 'ttml2' : undefined) ??
         (metadata?.mimeType?.includes('vtt') === true ? 'vtt' : undefined);
     if (extension === undefined) return;
-    return { label: language || detectedSubtitleLabel, language: language || undefined, url, extension };
+    const language = lang || undefined;
+    return {
+        label: genericSubtitleDisplayLabel(undefined, language, detectedSubtitleLabel),
+        language,
+        url,
+        extension,
+    };
 }
 
 function standaloneHlsTrack(manifestUrl: string, manifest: any): VideoDataSubtitleTrack | undefined {

--- a/extension/src/pages/base-generic-page.test.ts
+++ b/extension/src/pages/base-generic-page.test.ts
@@ -100,7 +100,7 @@ afterEach(() => {
 it('returns only native subtitle and caption tracks from the requested video', () => {
     const requestedVideo = appendVideo();
     requestedVideo.innerHTML = `
-        <track kind="subtitles" src="/subs/en.vtt" srclang="en" label="English">
+        <track kind="subtitles" src="/subs/en.vtt" srclang="en" label="en">
         <track kind="captions" src="/subs/ja" srclang="ja">
         <track kind="chapters" src="/chapters.vtt" label="Chapters">
         <track kind="subtitles" src="" label="Empty">
@@ -116,7 +116,7 @@ it('returns only native subtitle and caption tracks from the requested video', (
             extension: 'vtt',
         },
         {
-            label: 'ja',
+            label: '日本語',
             language: 'ja',
             url: 'http://localhost/subs/ja',
             extension: 'vtt',
@@ -145,7 +145,7 @@ it('serializes a populated programmatic text track without changing its mode', (
     const tracks = nativeSubtitleTracks(video);
 
     expect(tracks).toHaveLength(1);
-    expect(tracks[0]).toMatchObject({ label: 'English', language: 'en-us', extension: 'srt' });
+    expect(tracks[0]).toMatchObject({ label: 'English (United States)', language: 'en-us', extension: 'srt' });
     expect((tracks[0].url as string).split(',', 1)[0]).toBe('data:application/x-subrip;charset=utf-8');
     expect(decodeURIComponent((tracks[0].url as string).split(',', 2)[1])).toBe(
         '0\r\n00:00:01,250 --> 00:00:03,500\r\nFirst line\r\nSecond line\r\n\r\n' +
@@ -211,8 +211,8 @@ it('discovers strict subtitle metadata from small explicitly typed inline JSON',
     await expect(new BaseGenericPageDiscovery().videoData(video)).resolves.toMatchObject({
         subtitles: [
             { label: 'English', language: 'en', url: 'http://localhost/subs/en.vtt', extension: 'vtt' },
-            { label: 'Japanese', language: 'ja', url: 'http://localhost/subs/ja.ass?token=x', extension: 'ass' },
-            { label: 'es', language: 'es', url: 'http://localhost/subs/es', extension: 'vtt' },
+            { label: '日本語', language: 'ja', url: 'http://localhost/subs/ja.ass?token=x', extension: 'ass' },
+            { label: 'Español', language: 'es', url: 'http://localhost/subs/es', extension: 'vtt' },
         ],
     });
 });
@@ -319,7 +319,7 @@ it('discovers direct subtitle resources from the bounded performance timeline', 
         await expect(new BaseGenericPageDiscovery().videoData(video)).resolves.toMatchObject({
             subtitles: [
                 {
-                    label: 'en',
+                    label: 'English',
                     language: 'en',
                     url: 'https://cdn.example/subtitles/en.srt?token=x',
                     extension: 'srt',

--- a/extension/src/pages/base-generic-page.ts
+++ b/extension/src/pages/base-generic-page.ts
@@ -12,6 +12,7 @@ import {
     bindVideoDataDiscovery,
     deduplicateTracks,
     detectedSubtitleLabel,
+    genericSubtitleDisplayLabel,
     isJsonContentType,
     nonEmptyString,
     normalizedContentType,
@@ -88,7 +89,7 @@ function directSubtitleTracksFromPerformance(): VideoDataSubtitleTrack[] {
 
             tracks.push(
                 trackFromDef({
-                    label: language ?? detectedSubtitleLabel,
+                    label: genericSubtitleDisplayLabel(undefined, language, detectedSubtitleLabel),
                     language,
                     url,
                     extension,
@@ -235,7 +236,11 @@ export function nativeSubtitleTracks(
         const language = element.getAttribute('srclang')?.trim().toLowerCase() || undefined;
         tracks.push(
             trackFromDef({
-                label: element.getAttribute('label')?.trim() || language || `Subtitle ${index + 1}`,
+                label: genericSubtitleDisplayLabel(
+                    element.getAttribute('label') ?? undefined,
+                    language,
+                    `Subtitle ${index + 1}`
+                ),
                 language,
                 url,
                 // HTML track resources are WebVTT even when served by an extensionless endpoint.
@@ -260,9 +265,11 @@ export function nativeSubtitleTracks(
             const language = textTrack.language.trim().toLowerCase() || undefined;
             tracks.push(
                 trackFromDef({
-                    label: `${textTrack.label.trim() || language || `Subtitle ${trackElements.length + index + 1}`}${
-                        accumulated.capturedOverTime ? capturedDuringPlaybackLabelSuffix : ''
-                    }`,
+                    label: `${genericSubtitleDisplayLabel(
+                        textTrack.label,
+                        language,
+                        `Subtitle ${trackElements.length + index + 1}`
+                    )}${accumulated.capturedOverTime ? capturedDuringPlaybackLabelSuffix : ''}`,
                     language,
                     url: `data:application/x-subrip;charset=utf-8,${encodeURIComponent(text)}`,
                     extension: 'srt',

--- a/extension/src/pages/m3u8-util.test.ts
+++ b/extension/src/pages/m3u8-util.test.ts
@@ -40,7 +40,7 @@ it('fetches subtitle track segments and resolves relative URIs against each mani
             [
                 'https://cdn.example/media/master.m3u8',
                 `#EXTM3U
-#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",LANGUAGE="en",URI="subs/en.m3u8"
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="en",LANGUAGE="en",URI="subs/en.m3u8"
 #EXT-X-STREAM-INF:BANDWIDTH=1280000,SUBTITLES="subs"
 video.m3u8`,
             ],
@@ -142,8 +142,8 @@ video.m3u8`);
     );
 
     expect(tracks).toMatchObject([
-        { label: 'TTML', extension: 'ttml2' },
-        { label: 'Other', extension: 'scc' },
+        { label: 'English · TTML', extension: 'ttml2' },
+        { label: '日本語 · Other', extension: 'scc' },
     ]);
 });
 

--- a/extension/src/pages/m3u8-util.ts
+++ b/extension/src/pages/m3u8-util.ts
@@ -1,4 +1,5 @@
 import type { VideoDataSubtitleTrack } from '@project/common';
+import { detectedSubtitleLabel, genericSubtitleDisplayLabel } from '@project/extension/src/pages/subtitle-discovery';
 import { Parser } from 'm3u8-parser';
 import {
     extractExtension,
@@ -105,9 +106,10 @@ export async function subtitleTrackSegmentsFromM3U8Manifest(
                                     (segment: any) => new URL(segment.uri, loadedManifest.url).href
                                 );
                                 const rawExtension = extractExtension(urls[0], 'vtt').toLowerCase();
+                                const language = typeof track.language === 'string' ? track.language : undefined;
                                 return trackFromDef({
-                                    label: label,
-                                    language: typeof track.language === 'string' ? track.language : undefined,
+                                    label: genericSubtitleDisplayLabel(label, language, detectedSubtitleLabel),
+                                    language,
                                     url: urls,
                                     extension:
                                         // A best-effort heuristic to treat XML subtitle segments in HLS as TTML

--- a/extension/src/pages/subtitle-discovery.test.ts
+++ b/extension/src/pages/subtitle-discovery.test.ts
@@ -6,12 +6,15 @@ import {
     basenameForVideo,
     bindVideoDataDiscovery,
     deduplicateTracks,
+    detectedSubtitleLabel,
+    genericSubtitleDisplayLabel,
     hasSubtitleMetadataHint,
     isJsonContentType,
     normalizedContentType,
     responseTextWithinLimit,
     tracksFromJson,
 } from '@project/extension/src/pages/subtitle-discovery';
+import { languageDisplayName } from '@project/extension/src/pages/util';
 
 function appendVideo() {
     const video = document.createElement('video');
@@ -34,6 +37,66 @@ afterEach(() => {
     document.head.querySelectorAll('meta[property="og:title"]').forEach((element) => element.remove());
     document.title = '';
     history.replaceState(null, '', '/');
+});
+
+it('selects the best generic subtitle display label', () => {
+    expect(genericSubtitleDisplayLabel('Spanish commentary', 'es-ES', detectedSubtitleLabel)).toBe(
+        'Español (España) · commentary'
+    );
+    expect(genericSubtitleDisplayLabel('es', undefined, detectedSubtitleLabel)).toBe('Español');
+    expect(genericSubtitleDisplayLabel(undefined, 'es-ES', detectedSubtitleLabel)).toBe('Español (España)');
+    expect(genericSubtitleDisplayLabel(undefined, undefined, detectedSubtitleLabel)).toBe(detectedSubtitleLabel);
+});
+
+it('appends unresolvable language tags to the available label using the dot separator', () => {
+    expect(genericSubtitleDisplayLabel('Commentary', 'qaa', detectedSubtitleLabel)).toBe('Commentary · qaa');
+    expect(genericSubtitleDisplayLabel(undefined, 'qaa', detectedSubtitleLabel)).toBe(`${detectedSubtitleLabel} · qaa`);
+});
+
+it.each([
+    ['SDH', 'sdh', ['SDH', 'sdh', 'Sdh']],
+    ['HI', 'hi', ['HI', 'hi', 'Hi']],
+    ['OC', 'oc', ['OC', 'oc', 'Oc']],
+    ['VI', 'vi', ['VI', 'vi', 'Vi']],
+    ['ALT', 'alt', ['ALT', 'alt', 'Alt']],
+    ['FAN', 'fan', ['FAN', 'fan', 'Fan']],
+])(
+    'recognizes the subtitle qualifier %s case-insensitively instead of as language code %s',
+    (_qualifier, language, labels) => {
+        const languageDisplay = languageDisplayName(language);
+
+        for (const label of labels) {
+            expect(genericSubtitleDisplayLabel(label, undefined, detectedSubtitleLabel)).toBe(label);
+            expect(genericSubtitleDisplayLabel(label, language, detectedSubtitleLabel)).toBe(
+                `${languageDisplay} · ${label}`
+            );
+        }
+    }
+);
+
+it('omits language-code labels that are redundant with the supplied language', () => {
+    expect(genericSubtitleDisplayLabel('en', 'en', detectedSubtitleLabel)).toBe('English');
+    expect(genericSubtitleDisplayLabel('eng', 'en-US', detectedSubtitleLabel)).toBe('English (United States)');
+    expect(genericSubtitleDisplayLabel('es', 'es-ES', detectedSubtitleLabel)).toBe('Español (España)');
+});
+
+it('preserves label details while adding or refining its language display name', () => {
+    expect(genericSubtitleDisplayLabel('SDH', 'en-US', detectedSubtitleLabel)).toBe('English (United States) · SDH');
+    expect(genericSubtitleDisplayLabel('English SDH', 'en-US', detectedSubtitleLabel)).toBe(
+        'English (United States) · SDH'
+    );
+    expect(genericSubtitleDisplayLabel('English (United States) SDH', 'en-US', detectedSubtitleLabel)).toBe(
+        'English (United States) · SDH'
+    );
+    expect(genericSubtitleDisplayLabel('English', 'en-US', detectedSubtitleLabel)).toBe('English (United States)');
+});
+
+it('recognizes localized language names as equivalent to the supplied language', () => {
+    expect(genericSubtitleDisplayLabel('Japanese', 'ja', detectedSubtitleLabel)).toBe('日本語');
+    expect(genericSubtitleDisplayLabel('Portuguese', 'pt-BR', detectedSubtitleLabel)).toBe('Português (Brasil)');
+    expect(genericSubtitleDisplayLabel('Spanish commentary', 'es-ES', detectedSubtitleLabel)).toBe(
+        'Español (España) · commentary'
+    );
 });
 
 it('normalizes JSON MIME types and restricts resolved URLs to supported protocols', () => {
@@ -95,7 +158,7 @@ it('accepts a supported format as strict subtitle evidence', () => {
         ).tracks
     ).toMatchObject([
         {
-            label: 'English auto-generated',
+            label: 'English (United States) · auto-generated',
             language: 'eng-us',
             url: 'https://cdn.example/opaque',
             extension: 'vtt',
@@ -120,7 +183,7 @@ it('uses baseUrl as a source only inside strong subtitle context', () => {
 
     expect(contextual.extensionlessTracks).toEqual([
         {
-            label: 'Portuguese',
+            label: 'Português (Brasil)',
             language: 'pt-br',
             url: 'https://cdn.example/timedtext?id=1',
         },
@@ -135,11 +198,28 @@ it('uses baseUrl as a source only inside strong subtitle context', () => {
 });
 
 it('discovers contextual string tracks but keeps strict discovery unambiguous', () => {
-    const metadata = { subtitles: { English: '/captions/en.vtt', ignored: '/video.mp4' } };
+    const metadata = { subtitles: { ja: '/captions/ja.vtt', ignored: '/video.mp4' } };
 
     expect(tracksFromJson(metadata, 'http://localhost/').tracks).toEqual([]);
     expect(tracksFromJson(metadata, 'http://localhost/', { contextual: true }).tracks).toMatchObject([
-        { label: 'English', url: 'http://localhost/captions/en.vtt', extension: 'vtt' },
+        { label: '日本語', url: 'http://localhost/captions/ja.vtt', extension: 'vtt' },
+    ]);
+});
+
+it('adds language display names without discarding explicit JSON labels', () => {
+    const discovery = tracksFromJson(
+        {
+            tracks: [
+                { kind: 'subtitles', src: '/captions/ja.vtt', language: 'ja', label: 'ja' },
+                { kind: 'captions', src: '/captions/es.vtt', language: 'es', label: 'Spanish commentary' },
+            ],
+        },
+        'http://localhost/'
+    );
+
+    expect(discovery.tracks).toMatchObject([
+        { label: '日本語', language: 'ja', url: 'http://localhost/captions/ja.vtt' },
+        { label: 'Español · commentary', language: 'es', url: 'http://localhost/captions/es.vtt' },
     ]);
 });
 
@@ -182,7 +262,7 @@ it('inherits subtitle metadata through namespaced JSON-serialized XML', () => {
         }).tracks
     ).toMatchObject([
         {
-            label: 'ko',
+            label: '한국어',
             language: 'ko',
             url: 'https://cdn.example.com/captions/korean',
             extension: 'vtt',
@@ -201,7 +281,7 @@ it('uses response provenance as root subtitle context', () => {
         }).tracks
     ).toMatchObject([
         {
-            label: 'es',
+            label: 'Español',
             language: 'es',
             url: 'https://example.com/resources/spanish.vtt',
             extension: 'vtt',

--- a/extension/src/pages/subtitle-discovery.ts
+++ b/extension/src/pages/subtitle-discovery.ts
@@ -1,5 +1,12 @@
 import type { VideoData, VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/common';
-import { extractExtension, normalizeSubtitleExtension, trackFromDef } from '@project/extension/src/pages/util';
+import {
+    canonicalLanguageTag,
+    extractExtension,
+    getLocale,
+    languageDisplayName,
+    normalizeSubtitleExtension,
+    trackFromDef,
+} from '@project/extension/src/pages/util';
 
 export interface VideoDataProvider {
     videoData(video: HTMLVideoElement, reset?: boolean): Promise<VideoData>;
@@ -29,6 +36,8 @@ const subtitleContainerHint =
 const subtitleSourceHint =
     /"(?:baseurl|file|src|source|url)"\s*:\s*"[^"]*(?:caption|subtit|texttrack|timedtext|transcript|\.ass(?:[?#]|$)|\.dfxp(?:[?#]|$)|\.srt(?:[?#]|$)|\.ssa(?:[?#]|$)|\.ttml(?:[?#]|$)|\.vtt(?:[?#]|$))/i;
 const subtitleKindHint = /"kind"\s*:\s*"(?:captions?|subtitles?)"/i;
+const regexSpecialCharacters = /[.*+?^${}()|[\]\\]/g;
+const nonLanguageSubtitleLabels = new Set(['SDH', 'HI', 'OC', 'VI', 'ALT', 'FAN']);
 
 export const subtitleExtensionsByContentType: Readonly<Record<string, string>> = {
     'application/dfxp+xml': 'dfxp',
@@ -51,6 +60,86 @@ export const subtitleExtensionsByContentType: Readonly<Record<string, string>> =
     'text/x-srt': 'srt',
     'text/x-ssa': 'ass',
 };
+
+/** Matches a localized language name inside a subtitle label so it can be detected or replaced literally. */
+function caseInsensitivePattern(value: string) {
+    return new RegExp(value.replace(regexSpecialCharacters, '\\$&'), 'iu');
+}
+
+function isNonLanguageSubtitleLabel(label: string) {
+    return nonLanguageSubtitleLabels.has(label.toUpperCase());
+}
+
+function combineLanguageDisplayAndLabel(languageDisplay: string, label: string, languageInLabel?: RegExp) {
+    const detail = languageInLabel ? label.replace(languageInLabel, '').trim() : label;
+    return detail ? `${languageDisplay} · ${detail}` : languageDisplay;
+}
+
+function localizedLanguagePatterns(locale: Intl.Locale): readonly RegExp[] {
+    const displayLocales = new Map<string, Intl.Locale>();
+    for (const displayLanguage of [locale.baseName, 'en', ...navigator.languages]) {
+        const displayLocale = getLocale(displayLanguage);
+        if (displayLocale) displayLocales.set(displayLocale.baseName, displayLocale);
+    }
+
+    const languageTags = new Set([locale.baseName, locale.language]);
+    const names = new Set<string>();
+
+    for (const displayLocale of displayLocales.values()) {
+        for (const languageTag of languageTags) {
+            names.add(languageDisplayName(languageTag, displayLocale));
+        }
+    }
+
+    return [...names].sort((a, b) => b.length - a.length).map(caseInsensitivePattern);
+}
+
+/**
+ * Generates a display label for a subtitle track by combining the language display name and the parsed label.
+ * See the test cases for examples of how labels are combined with language display names.
+ */
+export function genericSubtitleDisplayLabel(
+    parsedLabel: string | undefined,
+    language: string | undefined,
+    fallback: string
+): string {
+    const label = parsedLabel?.trim();
+    const normalizedLanguage = language?.trim();
+
+    const locale = normalizedLanguage ? getLocale(normalizedLanguage) : undefined;
+    const languageDisplay = normalizedLanguage ? languageDisplayName(normalizedLanguage, locale) : undefined;
+    const languageResolved = languageDisplay !== undefined && languageDisplay !== normalizedLanguage;
+
+    if (label && normalizedLanguage) {
+        if (!languageResolved) return `${label} · ${normalizedLanguage}`;
+
+        const labelLocale = isNonLanguageSubtitleLabel(label) ? undefined : getLocale(label);
+        const canonicalLabel = labelLocale ? canonicalLanguageTag(labelLocale) : undefined;
+        if (
+            locale &&
+            canonicalLabel &&
+            (canonicalLabel === canonicalLanguageTag(locale) || canonicalLabel === locale.language)
+        ) {
+            return languageDisplay;
+        }
+
+        if (locale) {
+            const languageInLabel = localizedLanguagePatterns(locale).find((pattern) => pattern.test(label));
+            if (languageInLabel) return combineLanguageDisplayAndLabel(languageDisplay, label, languageInLabel);
+        }
+
+        return combineLanguageDisplayAndLabel(languageDisplay, label);
+    }
+
+    if (label) {
+        if (isNonLanguageSubtitleLabel(label)) return label;
+        const labelDisplay = languageDisplayName(label);
+        return labelDisplay !== label ? labelDisplay : label;
+    }
+    if (languageResolved) return languageDisplay;
+    if (normalizedLanguage) return `${fallback} · ${normalizedLanguage}`;
+    return fallback;
+}
 
 export function normalizedContentType(contentType: unknown) {
     return typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : undefined;
@@ -186,7 +275,7 @@ function trackDefinitionFromMetadata(
     if (extension === undefined) return;
 
     const normalizedLanguage = metadataLanguage(value) ?? inheritedLanguage;
-    const label = metadataLabel(value) ?? normalizedLanguage ?? detectedSubtitleLabel;
+    const label = genericSubtitleDisplayLabel(metadataLabel(value), normalizedLanguage, detectedSubtitleLabel);
 
     return { label, language: normalizedLanguage, url, extension };
 }
@@ -293,7 +382,11 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                     extractExtension(url, '') === '' &&
                     !extensionlessTracks.some((track) => track.url === url)
                 ) {
-                    extensionlessTracks.push({ label: label ?? language ?? detectedSubtitleLabel, language, url });
+                    extensionlessTracks.push({
+                        label: genericSubtitleDisplayLabel(label, language, detectedSubtitleLabel),
+                        language,
+                        url,
+                    });
                 }
             }
 
@@ -317,7 +410,12 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                     else if (referenceUrl !== undefined && referenceExtension !== undefined) {
                         tracks.push(
                             trackFromDef({
-                                label: inheritedLanguage ?? normalizedMetadataKey(key),
+                                label: genericSubtitleDisplayLabel(
+                                    normalizedMetadataKey(key),
+                                    inheritedLanguage,
+                                    detectedSubtitleLabel
+                                ),
+                                language: inheritedLanguage,
                                 url: referenceUrl,
                                 extension: referenceExtension,
                             })
@@ -327,7 +425,14 @@ export function tracksFromJson(value: unknown, baseUrl: string, options: JsonDis
                     const url = absoluteSubtitleUrl(child, baseUrl);
                     const extension = url === undefined ? undefined : subtitleExtensionForUrl(url);
                     if (url !== undefined && extension !== undefined) {
-                        tracks.push(trackFromDef({ label: key || detectedSubtitleLabel, url, extension }));
+                        tracks.push(
+                            trackFromDef({
+                                label: genericSubtitleDisplayLabel(key, inheritedLanguage, detectedSubtitleLabel),
+                                language: inheritedLanguage,
+                                url,
+                                extension,
+                            })
+                        );
                     }
                 }
             }

--- a/extension/src/pages/util.test.ts
+++ b/extension/src/pages/util.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 import {
     canonicalLanguageTag,
     extractExtension,
+    getLocale,
     inferTracks,
     languageDisplayName,
     mediaSourceIdentity,
@@ -55,12 +56,21 @@ describe('subtitleFileExtensionForUrl', () => {
 });
 
 describe('language names', () => {
+    it('parses normalized locales and rejects invalid language tags', () => {
+        expect(getLocale(' PT_br ')?.baseName).toBe('pt-BR');
+        expect(getLocale('ja-JP-u-ca-japanese')?.language).toBe('ja');
+        expect(getLocale('invalid!')).toBeUndefined();
+    });
+
     it('canonicalizes whitespace and underscore-separated BCP-47 language tags', () => {
         expect(canonicalLanguageTag(' PT_br ')).toBe('pt-BR');
     });
 
     it('removes Unicode locale extensions from canonical language tags', () => {
         expect(canonicalLanguageTag('ja-JP-u-ca-japanese')).toBe('ja-JP');
+        const locale = getLocale('ja-JP-u-ca-japanese');
+        expect(locale).toBeDefined();
+        if (locale) expect(canonicalLanguageTag(locale)).toBe('ja-JP');
     });
 
     it('returns undefined for invalid language tags', () => {
@@ -69,7 +79,7 @@ describe('language names', () => {
 
     it('uses each canonical language autonym with standard language display', () => {
         expect(languageDisplayName('ja')).toBe('日本語');
-        expect(languageDisplayName('es-419')).toBe('español (Latinoamérica)');
+        expect(languageDisplayName('es-419')).toBe('Español (Latinoamérica)');
         expect(languageDisplayName(' JA_jp-u-ca-japanese ')).toBe('日本語 (日本)');
     });
 

--- a/extension/src/pages/util.ts
+++ b/extension/src/pages/util.ts
@@ -1,26 +1,40 @@
 import { asbError } from '@project/common/util';
 import type { VideoDataSubtitleTrack, VideoDataSubtitleTrackDef } from '@project/common';
 
-export function canonicalLanguageTag(language: string): string | undefined {
+export function getLocale(language: string): Intl.Locale | undefined {
     try {
-        return new Intl.Locale(language.trim().replace(/_/g, '-')).baseName; // baseName removes extensions such as "-u-ca-gregory"
+        return new Intl.Locale(language.trim().replace(/_/g, '-'));
     } catch {
         return;
     }
 }
 
-export function languageDisplayName(language: string): string {
+export function canonicalLanguageTag(language: Intl.Locale): string;
+export function canonicalLanguageTag(language: string): string | undefined;
+export function canonicalLanguageTag(language: string | Intl.Locale): string | undefined {
+    const locale = typeof language === 'string' ? getLocale(language) : language;
+    return locale?.baseName; // baseName normalizes for Intl.DisplayNames
+}
+
+function capitalizeFirstLetter(value: string, locale: string): string {
+    const firstCodePoint = value.codePointAt(0);
+    if (firstCodePoint === undefined) return value;
+    const firstCharacter = String.fromCodePoint(firstCodePoint);
+    return firstCharacter.toLocaleUpperCase(locale) + value.slice(firstCharacter.length);
+}
+
+export function languageDisplayName(language: string, locale: Intl.Locale | undefined = getLocale(language)): string {
     const canonical = canonicalLanguageTag(language);
-    if (canonical === undefined) return language;
+    if (canonical === undefined || locale === undefined) return language;
 
     try {
-        return (
-            new Intl.DisplayNames([canonical], {
-                type: 'language',
-                languageDisplay: 'standard',
-                fallback: 'none',
-            }).of(canonical) ?? language
-        );
+        const displayLocale = canonicalLanguageTag(locale);
+        const displayName = new Intl.DisplayNames([displayLocale], {
+            type: 'language',
+            languageDisplay: 'standard',
+            fallback: 'none',
+        }).of(canonical);
+        return displayName === undefined ? language : capitalizeFirstLetter(displayName, displayLocale);
     } catch {
         return language;
     }


### PR DESCRIPTION
(To be merged after #1094)

During my review of that PR I realized we can parse the language codes to get readable labels for the subtitles from the generic parser. One of the biggest pain points was using the language code or non descriptive titles which can make selection confusing. 

We will now try to use all the information we have to create the best title while preserving as much information as possible without redundancies. This is achieved my making heavy usage of `Intl` classes to parse the language codes and format the labels. Rather than listing the examples here, I think the test cases do a better job of illustrating the what's happening.

One thing to note is that we try to display the language in the locale of the language, so instead of `Japanese` we see `日本語`. I think this makes the most sense and is usually how I see it done but we could also pass in the asbplayer current locale.

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
