### PR TITLE
Stable subtitle layout across overlapping subtitles

### DIFF
--- a/common/app/components/Player.tsx
+++ b/common/app/components/Player.tsx
@@ -438,7 +438,7 @@ function PlayerComponent(
         const playbackEngine = new PlaybackEngine({
             settingsProvider,
             appIntegration: extension.supportsAppIntegration,
-            autoPauseCorrectionSuppressed: false,
+            autoPauseCorrectionDisabled: false,
             subtitles: subtitlesRef.current ?? [],
             playbackModesDisabled: true,
             playbackModesSuppressed: false,

--- a/common/app/components/VideoPlayer.tsx
+++ b/common/app/components/VideoPlayer.tsx
@@ -41,6 +41,7 @@ import {
     subtitleTimestampWithDelay,
     errorMessageFromVideo,
     formatAsSignedMs,
+    mapSubtitlesForDisplay,
     timeDurationDisplay,
 } from '@project/common/util';
 import { HoveredToken, renderRichTextOntoSubtitles, getAnnotationsHtml } from '@project/common/annotations';
@@ -190,6 +191,7 @@ const showingSubtitleHtml = (
 
 interface CachedShowingSubtitleProps {
     subtitle: IndexedSubtitleModel;
+    visible: boolean;
     domCache: OffscreenDomCache;
     renderHtml: (subtitle: IndexedSubtitleModel) => string;
     className?: string;
@@ -199,6 +201,7 @@ interface CachedShowingSubtitleProps {
 
 const CachedShowingSubtitle = React.memo(function CachedShowingSubtitle({
     subtitle,
+    visible,
     domCache,
     renderHtml,
     className,
@@ -208,6 +211,8 @@ const CachedShowingSubtitle = React.memo(function CachedShowingSubtitle({
     return (
         <div
             className={className ? className : ''}
+            aria-hidden={!visible}
+            style={visible ? { pointerEvents: 'auto' } : { visibility: 'hidden', pointerEvents: 'none' }}
             onMouseOver={onMouseOver}
             onMouseOut={onMouseOut}
             ref={(ref) => {
@@ -260,6 +265,7 @@ const SubtitleContainer = React.forwardRef<HTMLDivElement, SubtitleContainerProp
                     : { top: subtitleSettings.topSubtitlePositionOffset + baseOffset }),
                 ...(subtitleSettings.subtitlesWidth === -1 ? {} : { width: `${subtitleSettings.subtitlesWidth}%` }),
                 zIndex: subtitleZIndex ? 12 : 0,
+                pointerEvents: 'none',
             }}
         >
             {children}
@@ -382,6 +388,7 @@ export default function VideoPlayer({
     const subtitlesRef = useRef(subtitles);
     subtitlesRef.current = subtitles;
     const [showSubtitles, setShowSubtitles] = useState<IndexedSubtitleModel[]>([]);
+    const [invisibleSubtitles, setInvisibleSubtitles] = useState<IndexedSubtitleModel[]>([]);
     const [miscSettings, setMiscSettings] = useState<MiscSettings>(settings);
     const miscSettingsRef = useRef(miscSettings);
     miscSettingsRef.current = miscSettings;
@@ -410,7 +417,10 @@ export default function VideoPlayer({
     const [, setTopSubtitlePositionOffset] = useState<number>(subtitleSettings.topSubtitlePositionOffset);
     const showSubtitlesRef = useRef<IndexedSubtitleModel[]>([]);
     showSubtitlesRef.current = showSubtitles;
+    const invisibleSubtitlesRef = useRef<IndexedSubtitleModel[]>([]);
+    invisibleSubtitlesRef.current = invisibleSubtitles;
     const showingSubtitleIndexesRef = useRef<readonly number[]>([]);
+    const invisibleSubtitleIndexesRef = useRef<readonly number[]>([]);
     const playbackStateChangedRef = useRef<(state: PlaybackState) => void>(() => {});
     const clock = useMemo<Clock>(() => new Clock(() => performance.now()), []);
     const mousePositionRef = useRef<Point | undefined>(undefined);
@@ -620,7 +630,7 @@ export default function VideoPlayer({
         const playbackEngine = new PlaybackEngine({
             settingsProvider,
             appIntegration: extension.supportsAppIntegration,
-            autoPauseCorrectionSuppressed: false,
+            autoPauseCorrectionDisabled: false,
             subtitles: subtitlesRef.current,
             playbackModesDisabled: false,
             playbackModesSuppressed: false,
@@ -850,6 +860,7 @@ export default function VideoPlayer({
             playerChannel.offset(offset);
 
             setShowSubtitles([]);
+            setInvisibleSubtitles([]);
         });
         playerChannel.onSubtitlesUpdated((updatedSubtitles) => {
             updateSubtitleDomCacheRef.current?.(updatedSubtitles);
@@ -1049,27 +1060,46 @@ export default function VideoPlayer({
         playerChannel.loadSubtitles();
     }, [playerChannel]);
 
-    const updateShowingSubtitles = useCallback((showingSubtitleIndexes: readonly number[]) => {
-        const showingSubtitles = showingSubtitleIndexes
-            .map((index) => subtitlesRef.current[index])
-            .filter(
-                (subtitle): subtitle is IndexedSubtitleModel =>
-                    subtitle !== undefined && !disabledSubtitleTracksRef.current[subtitle.track]
-            )
-            .slice()
-            .sort(compareSubtitlesForDisplay);
-        if (arrayEquals(showingSubtitles, showSubtitlesRef.current, (left, right) => left === right)) {
-            return;
-        }
+    const updateShowingSubtitles = useCallback(
+        (showingSubtitleIndexes: readonly number[], invisibleSubtitleIndexes: readonly number[]) => {
+            const subtitlesForIndexes = (indexes: readonly number[]) =>
+                indexes
+                    .map((index) => subtitlesRef.current[index])
+                    .filter(
+                        (subtitle): subtitle is IndexedSubtitleModel =>
+                            subtitle !== undefined && !disabledSubtitleTracksRef.current[subtitle.track]
+                    )
+                    .slice()
+                    .sort(compareSubtitlesForDisplay);
+            const showingSubtitles = subtitlesForIndexes(showingSubtitleIndexes);
+            const nextInvisibleSubtitles = subtitlesForIndexes(invisibleSubtitleIndexes);
+            const showingChanged = !arrayEquals(showingSubtitles, showSubtitlesRef.current);
+            const invisibleChanged = !arrayEquals(nextInvisibleSubtitles, invisibleSubtitlesRef.current);
+            if (!showingChanged && !invisibleChanged) return;
 
-        showSubtitlesRef.current = showingSubtitles;
-        setShowSubtitles(showingSubtitles);
-        if (showingSubtitles.length > 0 && miscSettingsRef.current.autoCopyCurrentSubtitle && document.hasFocus()) {
-            navigator.clipboard.writeText(showingSubtitles.map((subtitle) => subtitle.text).join('\n')).catch(() => {
-                // ignore
-            });
-        }
-    }, []);
+            if (showingChanged) {
+                showSubtitlesRef.current = showingSubtitles;
+                setShowSubtitles(showingSubtitles);
+            }
+            if (invisibleChanged) {
+                invisibleSubtitlesRef.current = nextInvisibleSubtitles;
+                setInvisibleSubtitles(nextInvisibleSubtitles);
+            }
+            if (
+                showingChanged &&
+                showingSubtitles.length > 0 &&
+                miscSettingsRef.current.autoCopyCurrentSubtitle &&
+                document.hasFocus()
+            ) {
+                navigator.clipboard
+                    .writeText(showingSubtitles.map((subtitle) => subtitle.text).join('\n'))
+                    .catch(() => {
+                        // ignore
+                    });
+            }
+        },
+        []
+    );
 
     playbackStateChangedRef.current = (state) => {
         const hiddenSubtitleIndexes = state.hiddenSubtitleIndexes ?? [];
@@ -1077,11 +1107,15 @@ export default function VideoPlayer({
             (index) => !hiddenSubtitleIndexes.includes(index)
         );
         showingSubtitleIndexesRef.current = visibleSubtitleIndexes;
-        updateShowingSubtitles(visibleSubtitleIndexes);
+        const invisibleSubtitleIndexes = (state.invisibleSubtitleIndexes ?? []).filter(
+            (index) => !hiddenSubtitleIndexes.includes(index)
+        );
+        invisibleSubtitleIndexesRef.current = invisibleSubtitleIndexes;
+        updateShowingSubtitles(visibleSubtitleIndexes, invisibleSubtitleIndexes);
     };
 
     useEffect(() => {
-        updateShowingSubtitles(showingSubtitleIndexesRef.current);
+        updateShowingSubtitles(showingSubtitleIndexesRef.current, invisibleSubtitleIndexesRef.current);
     }, [disabledSubtitleTracks, updateShowingSubtitles]);
 
     const handleOffsetChange = useCallback(
@@ -2002,11 +2036,11 @@ export default function VideoPlayer({
         parent?.document?.body !== undefined &&
         parent.document.body.clientWidth === document.body.clientWidth;
 
-    const subtitleAlignmentForTrack = (track: number) => subtitleAlignments[track] ?? subtitleAlignments[0];
-    const elementForSubtitle = (subtitle: IndexedSubtitleModel) => (
+    const elementForSubtitle = (subtitle: IndexedSubtitleModel, visible: boolean) => (
         <CachedShowingSubtitle
             key={subtitle.index}
             subtitle={subtitle}
+            visible={visible}
             domCache={domCacheRef.current ?? getSubtitleDomCache()}
             renderHtml={getSubtitleHtml}
             onMouseOver={handleSubtitleMouseOver}
@@ -2014,8 +2048,14 @@ export default function VideoPlayer({
         />
     );
 
-    const subtitleElementsWithAlignment = (alignment: SubtitleAlignment) =>
-        showSubtitles.filter((s) => subtitleAlignmentForTrack(s.track) === alignment).map(elementForSubtitle);
+    const subtitleAlignmentForTrack = (track: number) => subtitleAlignments[track] ?? subtitleAlignments[0];
+    const subtitleElementsWithAlignment = (alignment: SubtitleAlignment) => {
+        const showing = showSubtitles.filter((subtitle) => subtitleAlignmentForTrack(subtitle.track) === alignment);
+        const invisible = invisibleSubtitles.filter(
+            (subtitle) => subtitleAlignmentForTrack(subtitle.track) === alignment
+        );
+        return mapSubtitlesForDisplay(showing, invisible, elementForSubtitle);
+    };
     const topSubtitleElements = displaySubtitles ? subtitleElementsWithAlignment('top') : [];
     const bottomSubtitleElements = displaySubtitles ? subtitleElementsWithAlignment('bottom') : [];
     const mobileOverlayModel = () => {

--- a/common/app/services/player-channel.test.ts
+++ b/common/app/services/player-channel.test.ts
@@ -59,6 +59,30 @@ describe('PlayerChannel playback state', () => {
         channel.close();
     });
 
+    it('sends optional invisible subtitle indexes', () => {
+        const channel = new PlayerChannel('test-channel');
+        const broadcastChannel = TestBroadcastChannel.instance!;
+
+        channel.playbackState({
+            timestampMs: 1234,
+            showingSubtitleIndexes: [2],
+            invisibleSubtitleIndexes: [5],
+            paused: false,
+        });
+
+        expect(broadcastChannel.sent).toEqual([
+            {
+                command: 'playbackState',
+                timestampMs: 1234,
+                showingSubtitleIndexes: [2],
+                invisibleSubtitleIndexes: [5],
+                paused: false,
+            },
+        ]);
+
+        channel.close();
+    });
+
     it('delivers playback states in transport order', () => {
         const channel = new PlayerChannel('test-channel');
         const broadcastChannel = TestBroadcastChannel.instance!;

--- a/common/playback/controllers/playback-state-controller.test.ts
+++ b/common/playback/controllers/playback-state-controller.test.ts
@@ -32,6 +32,7 @@ const makeController = () => {
         showingSubtitlesAt: (timestampMs) =>
             subtitles.filter(({ start, end }) => timestampMs >= start && timestampMs < end),
         subtitlesVisible: () => state.subtitlesVisible,
+        invisibleSubtitlesAt: () => [],
         playbackStateChanged: (playbackState) => playbackStates.push(playbackState),
         now: () => nowMs,
     });
@@ -41,6 +42,32 @@ const makeController = () => {
 };
 
 describe('PlaybackStateController', () => {
+    it('publishes invisible indexes for layout placeholders', () => {
+        const playbackStates: PlaybackState[] = [];
+        const controller = new PlaybackStateController({
+            paused: () => false,
+            showingSubtitlesAt: () => [subtitles[0]],
+            subtitlesVisible: () => true,
+            invisibleSubtitlesAt: (timestampMs) => (timestampMs < 600 ? [] : [subtitles[1]]),
+            playbackStateChanged: (state) => playbackStates.push(state),
+            now: () => 0,
+        });
+        controller.bind();
+
+        controller.notify(500, { force: false });
+        controller.notify(600, { force: false });
+
+        expect(playbackStates).toEqual([
+            { timestampMs: 500, showingSubtitleIndexes: [0], paused: false },
+            {
+                timestampMs: 600,
+                showingSubtitleIndexes: [0],
+                invisibleSubtitleIndexes: [1],
+                paused: false,
+            },
+        ]);
+    });
+
     it('publishes one coherent state snapshot', () => {
         const harness = makeController();
         harness.state.currentTimeMs = 1500;
@@ -188,6 +215,31 @@ describe('PlaybackStateController', () => {
             hiddenSubtitleIndexes: [0],
             paused: false,
         });
+    });
+
+    it('publishes invisible placeholders while hidden and sorts all hidden indexes', () => {
+        const playbackStates: PlaybackState[] = [];
+        const controller = new PlaybackStateController({
+            paused: () => false,
+            showingSubtitlesAt: () => [subtitles[1]],
+            invisibleSubtitlesAt: () => [subtitles[0]],
+            subtitlesVisible: () => false,
+            playbackStateChanged: (state) => playbackStates.push(state),
+            now: () => 0,
+        });
+        controller.bind();
+
+        controller.notify(1500, { force: false });
+
+        expect(playbackStates).toEqual([
+            {
+                timestampMs: 1500,
+                showingSubtitleIndexes: [1],
+                invisibleSubtitleIndexes: [0],
+                hiddenSubtitleIndexes: [0, 1],
+                paused: false,
+            },
+        ]);
     });
 
     it('publishes a forced unchanged state during the throttle interval', () => {

--- a/common/playback/controllers/playback-state-controller.ts
+++ b/common/playback/controllers/playback-state-controller.ts
@@ -13,6 +13,7 @@ export interface PlaybackStateControllerOptions<T extends IndexedSubtitleModel> 
     readonly paused: () => boolean;
     readonly showingSubtitlesAt: (timestampMs: number) => readonly T[];
     readonly subtitlesVisible: () => boolean;
+    readonly invisibleSubtitlesAt: (timestampMs: number) => readonly T[];
     readonly playbackStateChanged: (state: PlaybackState) => void;
     readonly now: () => number;
 }
@@ -22,6 +23,7 @@ export default class PlaybackStateController<T extends IndexedSubtitleModel> {
     private readonly paused: () => boolean;
     private readonly showingSubtitlesAt: (timestampMs: number) => readonly T[];
     private readonly subtitlesVisible: () => boolean;
+    private readonly invisibleSubtitlesAt: (timestampMs: number) => readonly T[];
     private readonly playbackStateChanged: (state: PlaybackState) => void;
     private readonly now: () => number;
     private bindGeneration = 0;
@@ -29,22 +31,20 @@ export default class PlaybackStateController<T extends IndexedSubtitleModel> {
     private pendingForce = false;
     private pendingReconcile?: (timestampMs: number) => void;
     private lastNotifiedAt?: number;
-    private lastNotifiedState?: {
-        readonly paused: boolean;
-        readonly showingSubtitleIndexes: readonly number[];
-        readonly hiddenSubtitleIndexes: readonly number[];
-    };
+    private lastNotifiedState?: PlaybackState;
 
     constructor({
         paused,
         showingSubtitlesAt,
         subtitlesVisible,
+        invisibleSubtitlesAt,
         playbackStateChanged,
         now,
     }: PlaybackStateControllerOptions<T>) {
         this.paused = paused;
         this.showingSubtitlesAt = showingSubtitlesAt;
         this.subtitlesVisible = subtitlesVisible;
+        this.invisibleSubtitlesAt = invisibleSubtitlesAt;
         this.playbackStateChanged = playbackStateChanged;
         this.now = now;
     }
@@ -100,30 +100,34 @@ export default class PlaybackStateController<T extends IndexedSubtitleModel> {
         }
 
         const showingSubtitleIndexes = this.showingSubtitlesAt(timestampMs).map(({ index }) => index);
-        const hiddenSubtitleIndexes = this.subtitlesVisible() ? [] : showingSubtitleIndexes;
+        const invisibleSubtitleIndexes = this.invisibleSubtitlesAt(timestampMs).map(({ index }) => index);
+        const subtitlesVisible = this.subtitlesVisible();
+        const hiddenSubtitleIndexes =
+            !subtitlesVisible && (showingSubtitleIndexes.length || invisibleSubtitleIndexes.length)
+                ? [...showingSubtitleIndexes, ...invisibleSubtitleIndexes].sort((left, right) => left - right)
+                : undefined;
+
+        const state: PlaybackState = {
+            timestampMs,
+            showingSubtitleIndexes,
+            ...(invisibleSubtitleIndexes.length ? { invisibleSubtitleIndexes } : {}),
+            ...(hiddenSubtitleIndexes !== undefined ? { hiddenSubtitleIndexes } : {}),
+            paused: this.paused(),
+        };
         const previousState = this.lastNotifiedState;
         const stateChanged =
             previousState === undefined ||
-            previousState.paused !== this.paused() ||
-            !arrayEquals(previousState.showingSubtitleIndexes, showingSubtitleIndexes) ||
-            !arrayEquals(previousState.hiddenSubtitleIndexes, hiddenSubtitleIndexes);
+            previousState.paused !== state.paused ||
+            !arrayEquals(previousState.showingSubtitleIndexes, state.showingSubtitleIndexes) ||
+            !arrayEquals(previousState.invisibleSubtitleIndexes, state.invisibleSubtitleIndexes) ||
+            !arrayEquals(previousState.hiddenSubtitleIndexes, state.hiddenSubtitleIndexes);
         const now = this.now();
         if (!options.force && !stateChanged && this.lastNotifiedAt !== undefined && now - this.lastNotifiedAt < 1000) {
             return;
         }
 
-        const state: PlaybackState = {
-            timestampMs,
-            showingSubtitleIndexes,
-            ...(hiddenSubtitleIndexes.length ? { hiddenSubtitleIndexes } : {}),
-            paused: this.paused(),
-        };
         this.lastNotifiedAt = now;
-        this.lastNotifiedState = {
-            paused: state.paused,
-            showingSubtitleIndexes,
-            hiddenSubtitleIndexes,
-        };
+        this.lastNotifiedState = state;
         this.playbackStateChanged(state);
     }
 }

--- a/common/playback/plan/playback-plan-executor.test.ts
+++ b/common/playback/plan/playback-plan-executor.test.ts
@@ -352,11 +352,11 @@ describe('PlaybackPlanExecutor', () => {
         expect(harness.seeks).toEqual([1000]);
     });
 
-    it('separates playback-mode subtitles from all display subtitles showing at an automatic pause', async () => {
+    it('reports playback-mode subtitles and the timestamp for querying all display subtitles', async () => {
         const playbackSubtitle = makeSubtitle({ text: 'read me', track: 0, index: 0 });
         const displayOnlySubtitle = makeSubtitle({ text: 'translation', track: 1, index: 1 });
         const pausedWith: (readonly IndexedSubtitleModel[])[] = [];
-        const showingAtPause: (readonly IndexedSubtitleModel[])[] = [];
+        const pauseTimestamps: number[] = [];
         const harness = executorHarness(
             [PlayMode.autoPause],
             0,
@@ -366,9 +366,9 @@ describe('PlaybackPlanExecutor', () => {
                 autoPausePreference: AutoPausePreference.atStart,
             },
             {
-                pause: ({ playbackModeSubtitlesAtPause, showingSubtitlesAtPause }) => {
+                pause: ({ timestampMs, playbackModeSubtitlesAtPause }) => {
                     pausedWith.push(playbackModeSubtitlesAtPause);
-                    showingAtPause.push(showingSubtitlesAtPause);
+                    pauseTimestamps.push(timestampMs);
                 },
             }
         );
@@ -376,7 +376,11 @@ describe('PlaybackPlanExecutor', () => {
         await harness.executor.update(1000, {});
 
         expect(pausedWith).toEqual([[playbackSubtitle]]);
-        expect(showingAtPause).toEqual([[playbackSubtitle, displayOnlySubtitle]]);
+        expect(pauseTimestamps).toEqual([1000]);
+        expect(harness.executor.showingSubtitlesAt(pauseTimestamps[0])).toEqual([
+            playbackSubtitle,
+            displayOnlySubtitle,
+        ]);
     });
 
     it.each([

--- a/common/playback/plan/playback-plan-executor.ts
+++ b/common/playback/plan/playback-plan-executor.ts
@@ -18,8 +18,8 @@ export type PlaybackTimelineTransitionCause = 'user-seek' | 'internal-seek' | 'f
 export const maximumInternalSeekMismatchMs = 3000;
 
 export interface PlaybackPlanPause<T extends IndexedSubtitleModel> {
+    readonly timestampMs: number;
     readonly playbackModeSubtitlesAtPause: readonly T[];
-    readonly showingSubtitlesAtPause: readonly T[];
 }
 
 export interface PlaybackPlanExecutorCallbacks<T extends IndexedSubtitleModel> {
@@ -112,6 +112,10 @@ export default class PlaybackPlanExecutor<T extends IndexedSubtitleModel> {
 
     showingSubtitlesAt(timestampMs: number): readonly T[] {
         return this.timeline.showingSubtitlesAt(timestampMs);
+    }
+
+    invisibleSubtitlesAt(timestampMs: number): readonly T[] {
+        return this.timeline.invisibleSubtitlesAt(timestampMs);
     }
 
     replacePlan(
@@ -287,8 +291,8 @@ export default class PlaybackPlanExecutor<T extends IndexedSubtitleModel> {
         }
 
         this.callbacks.pause({
+            timestampMs: event.timestampMs,
             playbackModeSubtitlesAtPause: this.pauseSubtitlesFor([block]),
-            showingSubtitlesAtPause: this.showingSubtitlesAt(event.timestampMs),
         });
         return { autoPaused: true };
     }
@@ -306,8 +310,8 @@ export default class PlaybackPlanExecutor<T extends IndexedSubtitleModel> {
 
         if (action.pause && !options.alreadyAutoPaused) {
             this.callbacks.pause({
+                timestampMs: event.timestampMs,
                 playbackModeSubtitlesAtPause: this.pauseSubtitlesFor([block]),
-                showingSubtitlesAtPause: this.showingSubtitlesAt(event.timestampMs),
             });
         }
         if (repeat) {
@@ -365,8 +369,8 @@ export default class PlaybackPlanExecutor<T extends IndexedSubtitleModel> {
             const shouldPause = this.shouldPauseForCondensedSeek(target);
             const seek = this.seek(target, { includeAtTimestamp: !shouldPause });
             const pause = {
+                timestampMs: target,
                 playbackModeSubtitlesAtPause: this.pauseSubtitlesFor(this.timeline.startActionsAt(target)),
-                showingSubtitlesAtPause: this.showingSubtitlesAt(target),
             };
             if (shouldPause) this.callbacks.pause(pause);
             await seek;

--- a/common/playback/playback-engine.test.ts
+++ b/common/playback/playback-engine.test.ts
@@ -164,7 +164,7 @@ async function makePlaybackEngine(
         settingsReady: boolean;
         emitInitialDiscontinuity?: boolean;
         appIntegration?: boolean;
-        autoPauseCorrectionSuppressed?: boolean;
+        autoPauseCorrectionDisabled?: boolean;
         playbackModesDisabled?: boolean;
         playbackPositionKeys?: readonly string[];
         profile?: string;
@@ -223,7 +223,7 @@ async function makePlaybackEngine(
     const playbackEngine = new PlaybackEngine({
         settingsProvider,
         appIntegration: overrides.appIntegration ?? true,
-        autoPauseCorrectionSuppressed: overrides.autoPauseCorrectionSuppressed ?? false,
+        autoPauseCorrectionDisabled: overrides.autoPauseCorrectionDisabled ?? false,
         subtitles,
         playbackModesDisabled: overrides.playbackModesDisabled ?? false,
         playbackModesSuppressed: false,
@@ -665,7 +665,7 @@ describe('PlaybackEngine', () => {
                 activeProfile: async () => undefined,
             } as unknown as SettingsProvider,
             appIntegration: true,
-            autoPauseCorrectionSuppressed: false,
+            autoPauseCorrectionDisabled: false,
             subtitles: [],
             playbackModesDisabled: false,
             playbackModesSuppressed: false,
@@ -978,6 +978,82 @@ describe('PlaybackEngine', () => {
         });
     });
 
+    it('publishes changing invisible placeholders as showing membership changes within an overlap group', async () => {
+        const firstTrack = { ...subtitle, end: 5000, originalEnd: 5000, track: 0, index: 0 };
+        const secondTrack = {
+            ...secondSubtitle,
+            start: 3000,
+            originalStart: 3000,
+            end: 4000,
+            originalEnd: 4000,
+            track: 1,
+            index: 1,
+        };
+        const harness = await makePlaybackEngine([PlayMode.normal], 1500, [firstTrack, secondTrack]);
+
+        harness.playbackEngine.bind();
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 1500,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            paused: false,
+        });
+
+        await harness.driver.time(3500);
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 3500,
+            showingSubtitleIndexes: [0, 1],
+            paused: false,
+        });
+
+        await harness.driver.time(4500);
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 4500,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            paused: false,
+        });
+    });
+
+    it('stops rendering layout placeholders when subtitles become hidden', async () => {
+        const firstTrack = { ...subtitle, end: 5000, originalEnd: 5000, track: 0, index: 0 };
+        const secondTrack = {
+            ...secondSubtitle,
+            start: 3000,
+            originalStart: 3000,
+            end: 4000,
+            originalEnd: 4000,
+            track: 1,
+            index: 1,
+        };
+        const harness = await makePlaybackEngine([PlayMode.normal], 1500, [firstTrack, secondTrack], {
+            paused: true,
+            settings: { subtitleVisibility: SubtitleVisibility.whilePaused },
+        });
+
+        harness.playbackEngine.bind();
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 1500,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            paused: true,
+        });
+
+        await harness.driver.start();
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 1500,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            hiddenSubtitleIndexes: [0, 1],
+            paused: false,
+        });
+    });
+
     it('retains a live playback rate across every post-ready settings change', async () => {
         const harness = await makePlaybackEngine([PlayMode.normal], 1500, [subtitle], {
             settings: { rememberPlaybackRate: true },
@@ -1214,9 +1290,9 @@ describe('PlaybackEngine', () => {
         expect(harness.seeks).toEqual([1999]);
     });
 
-    it('auto-pauses without correcting the timestamp when correction is suppressed', async () => {
+    it('auto-pauses without correcting the timestamp when correction is disabled', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1239,9 +1315,43 @@ describe('PlaybackEngine', () => {
         });
     });
 
+    it('preserves layout placeholders from the auto-pause timestamp when correction is disabled', async () => {
+        const first = { ...subtitle, index: 0 };
+        const connecting = {
+            ...subtitle,
+            start: 1500,
+            originalStart: 1500,
+            end: 2500,
+            originalEnd: 2500,
+            track: 1,
+            index: 1,
+        };
+        const future = {
+            ...subtitle,
+            start: 2200,
+            originalStart: 2200,
+            end: 3000,
+            originalEnd: 3000,
+            track: 2,
+            index: 2,
+        };
+        const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [first, connecting, future], {
+            autoPauseCorrectionDisabled: true,
+        });
+
+        await harness.driver.time(3100);
+
+        expect(harness.playbackStates.at(-1)).toEqual({
+            timestampMs: 3100,
+            showingSubtitleIndexes: [0, 1],
+            invisibleSubtitleIndexes: [2],
+            paused: true,
+        });
+    });
+
     it('releases the automatic-pause subtitle snapshot on a user seek', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1256,7 +1366,7 @@ describe('PlaybackEngine', () => {
 
     it('publishes the released automatic-pause subtitle snapshot when a user seek is canceled', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1272,7 +1382,7 @@ describe('PlaybackEngine', () => {
 
     it('releases the automatic-pause subtitle snapshot when subtitles are replaced', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1287,7 +1397,7 @@ describe('PlaybackEngine', () => {
 
     it('publishes the released automatic-pause subtitle snapshot for an equivalent subtitle replacement', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1302,7 +1412,7 @@ describe('PlaybackEngine', () => {
 
     it('preserves an empty subtitle snapshot from the intended automatic-pause timestamp', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle, secondSubtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
             settings: { subtitleTriggerEndOffset: 500 },
         });
 
@@ -1317,7 +1427,7 @@ describe('PlaybackEngine', () => {
 
     it('releases the automatic-pause subtitle snapshot when subtitle visibility changes', async () => {
         const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-            autoPauseCorrectionSuppressed: true,
+            autoPauseCorrectionDisabled: true,
         });
 
         await harness.driver.time(2100);
@@ -1490,7 +1600,7 @@ describe('PlaybackEngine', () => {
                 activeProfile: async () => undefined,
             } as unknown as SettingsProvider,
             appIntegration: true,
-            autoPauseCorrectionSuppressed: false,
+            autoPauseCorrectionDisabled: false,
             subtitles: [subtitle],
             playbackModesDisabled: false,
             playbackModesSuppressed: false,
@@ -2058,7 +2168,7 @@ describe('PlaybackEngine', () => {
         try {
             const error = new Error('play failed');
             const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-                autoPauseCorrectionSuppressed: true,
+                autoPauseCorrectionDisabled: true,
                 settings: {
                     ...resumingAutoPauseSettings,
                     autoPausePreference: AutoPausePreference.atEnd,
@@ -2090,7 +2200,7 @@ describe('PlaybackEngine', () => {
 
         try {
             const harness = await makePlaybackEngine([PlayMode.autoPause], 1500, [subtitle], {
-                autoPauseCorrectionSuppressed: true,
+                autoPauseCorrectionDisabled: true,
                 settings: {
                     ...resumingAutoPauseSettings,
                     autoPausePreference: AutoPausePreference.atEnd,

--- a/common/playback/playback-engine.ts
+++ b/common/playback/playback-engine.ts
@@ -100,7 +100,7 @@ export interface PlaybackEngineCallbacks {
 export interface PlaybackEngineOptions<T extends IndexedSubtitleModel> {
     readonly settingsProvider: SettingsProvider;
     readonly appIntegration: boolean;
-    readonly autoPauseCorrectionSuppressed: boolean;
+    readonly autoPauseCorrectionDisabled: boolean;
     readonly subtitles: readonly T[];
     readonly playbackModesDisabled: boolean;
     readonly playbackModesSuppressed: boolean;
@@ -137,7 +137,7 @@ export interface PlaybackEngineOptions<T extends IndexedSubtitleModel> {
 export default class PlaybackEngine<T extends IndexedSubtitleModel> {
     private settings: AsbplayerSettings;
     private readonly appIntegration: boolean;
-    private readonly autoPauseCorrectionSuppressed: boolean;
+    private readonly autoPauseCorrectionDisabled: boolean;
     private readonly subtitleOffsetStorage = new CachedLocalStorage();
     private subtitles: readonly T[];
     private lastSubtitleEndMs?: number;
@@ -152,7 +152,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
     private readonly autoPauseController: AutoPauseController;
     private readonly subtitleVisibilityController: SubtitleVisibilityController;
     private readonly playbackStateController: PlaybackStateController<T>;
-    private autoPauseShowingSubtitlesSnapshot?: readonly T[];
+    private autoPauseTimestampMs?: number;
     private readonly settingsProvider: SettingsProvider;
     private unbindOperationId = 0;
     private settingsChangedOperationId = 0;
@@ -165,7 +165,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
     constructor({
         settingsProvider,
         appIntegration,
-        autoPauseCorrectionSuppressed,
+        autoPauseCorrectionDisabled,
         subtitles,
         playbackModesDisabled,
         playbackModesSuppressed,
@@ -175,7 +175,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
     }: PlaybackEngineOptions<T>) {
         this.settings = defaultSettings;
         this.appIntegration = appIntegration;
-        this.autoPauseCorrectionSuppressed = autoPauseCorrectionSuppressed;
+        this.autoPauseCorrectionDisabled = autoPauseCorrectionDisabled;
         this.settingsProvider = settingsProvider;
         this.subtitles = subtitles;
         this.lastSubtitleEndMs = this.calculateLastSubtitleEndMs(subtitles);
@@ -196,7 +196,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
             play: callbacks.play,
             resumeDelayStarted: () => this.subtitleVisibilityController.autoPauseResumeDelayStarted(),
             autoResumeFailed: () => {
-                const snapshotCleared = this.clearAutoPauseShowingSubtitlesSnapshot();
+                const snapshotCleared = this.clearAutoPauseTimestamp();
                 this.subtitleVisibilityController.autoPauseCancelled(this.timingDriver.paused());
                 if (snapshotCleared && this.timingDriver.bound) {
                     this.playbackStateController.notify(this.timingDriver.currentTimeMs(), { force: false });
@@ -209,8 +209,8 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
         const executorCallbacks: PlaybackPlanExecutorCallbacks<T> = {
             play: callbacks.play,
             paused: () => this.timingDriver.paused(),
-            pause: ({ playbackModeSubtitlesAtPause, showingSubtitlesAtPause }) => {
-                this.autoPauseShowingSubtitlesSnapshot = [...showingSubtitlesAtPause];
+            pause: ({ timestampMs, playbackModeSubtitlesAtPause }) => {
+                this.autoPauseTimestampMs = timestampMs;
                 this.subtitleVisibilityController.autoPaused();
                 this.autoPauseController.autoPaused(playbackModeSubtitlesAtPause);
                 callbacks.pause();
@@ -261,8 +261,10 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
         this.playbackStateController = new PlaybackStateController({
             paused: () => this.timingDriver.paused(),
             showingSubtitlesAt: (timestampMs) =>
-                this.autoPauseShowingSubtitlesSnapshot ?? this.executor.showingSubtitlesAt(timestampMs),
+                this.executor.showingSubtitlesAt(this.autoPauseTimestampMs ?? timestampMs),
             subtitlesVisible: () => this.subtitleVisibilityController.subtitlesVisible,
+            invisibleSubtitlesAt: (timestampMs) =>
+                this.executor.invisibleSubtitlesAt(this.autoPauseTimestampMs ?? timestampMs),
             playbackStateChanged: callbacks.playbackStateChanged,
             now: () => performance.now(),
         });
@@ -294,7 +296,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
                 this.playbackPositionController.discontinuity(currentTimestampMs);
                 const { cause } = this.executor.handleDiscontinuity(currentTimestampMs);
                 if (cause !== 'internal-seek') {
-                    this.clearAutoPauseShowingSubtitlesSnapshot();
+                    this.clearAutoPauseTimestamp();
                     this.autoPauseController.userSeeked();
                     this.subtitleVisibilityController.userSeeked(this.timingDriver.paused());
                 }
@@ -302,7 +304,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
             },
             onCancel: (options) => this.executor.cancelPendingOperations(options),
             onPlaybackStarted: async () => {
-                this.clearAutoPauseShowingSubtitlesSnapshot();
+                this.clearAutoPauseTimestamp();
                 this.autoPauseController.playbackStarted();
                 this.subtitleVisibilityController.playbackStarted();
                 await this.executor.playbackStarted();
@@ -431,7 +433,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
 
     private teardown({ saveSettings }: { readonly saveSettings: boolean }): void {
         ++this.unbindOperationId;
-        this.clearAutoPauseShowingSubtitlesSnapshot();
+        this.clearAutoPauseTimestamp();
         this.autoPauseController.cancel();
         this.subtitleVisibilityController.cancel();
         if (!saveSettings) this.playbackPositionController.profileChanged();
@@ -492,7 +494,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
 
     subtitlesChanged(subtitles: readonly T[]): void {
         const hadSubtitles = this.ready.subtitles;
-        const snapshotCleared = this.clearAutoPauseShowingSubtitlesSnapshot();
+        const snapshotCleared = this.clearAutoPauseTimestamp();
         this.subtitles = subtitles;
         this.lastSubtitleEndMs = this.calculateLastSubtitleEndMs(subtitles);
         if (subtitles.length) {
@@ -626,7 +628,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
         }
         const { cause } = this.executor.handleDiscontinuity(timestampMs);
         if (cause !== 'internal-seek') {
-            this.clearAutoPauseShowingSubtitlesSnapshot();
+            this.clearAutoPauseTimestamp();
             this.autoPauseController.userSeeked();
             this.subtitleVisibilityController.userSeeked(this.timingDriver.paused());
         }
@@ -645,7 +647,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
 
     private seekStartedWithCause(cause: PlaybackTimelineTransitionCause): void {
         if (cause === 'internal-seek') return;
-        const snapshotCleared = this.clearAutoPauseShowingSubtitlesSnapshot();
+        const snapshotCleared = this.clearAutoPauseTimestamp();
         this.autoPauseController.userSeeked();
         this.subtitleVisibilityController.userSeeked(this.timingDriver.paused());
         if (snapshotCleared && this.timingDriver.bound) {
@@ -709,7 +711,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
             const subtitleVisibilityChanged = this.plan.subtitleVisibility !== plan.subtitleVisibility;
             this.plan = plan;
             const autoPauseResumeChanged = this.autoPauseController.replacePlan(this.plan.autoPause?.resume);
-            if (autoPauseResumeChanged || subtitleVisibilityChanged) this.clearAutoPauseShowingSubtitlesSnapshot();
+            if (autoPauseResumeChanged || subtitleVisibilityChanged) this.clearAutoPauseTimestamp();
             this.subtitleVisibilityController.replacePlan(this.plan.subtitleVisibility, this.timingDriver.paused());
             if (autoPauseResumeChanged) {
                 this.subtitleVisibilityController.autoPauseCancelled(this.timingDriver.paused());
@@ -726,9 +728,9 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
         return planChanged;
     }
 
-    private clearAutoPauseShowingSubtitlesSnapshot(): boolean {
-        if (this.autoPauseShowingSubtitlesSnapshot === undefined) return false;
-        this.autoPauseShowingSubtitlesSnapshot = undefined;
+    private clearAutoPauseTimestamp(): boolean {
+        if (this.autoPauseTimestampMs === undefined) return false;
+        this.autoPauseTimestampMs = undefined;
         return true;
     }
 
@@ -758,7 +760,7 @@ export default class PlaybackEngine<T extends IndexedSubtitleModel> {
         timestampMs: number,
         warningCommand: 'pause-correction'
     ): Promise<{ seekIssued: boolean }> {
-        if (this.autoPauseCorrectionSuppressed) return { seekIssued: false };
+        if (this.autoPauseCorrectionDisabled) return { seekIssued: false };
         const targetTimestampMs = this.clampTimestamp(timestampMs);
         if (Math.abs(this.timingDriver.currentTimeMs() - targetTimestampMs) < playbackPlanCorrectionToleranceMs) {
             return { seekIssued: false };

--- a/common/playback/timeline/playback-timeline-compiler.ts
+++ b/common/playback/timeline/playback-timeline-compiler.ts
@@ -169,6 +169,66 @@ type DisplayEdge<T extends IndexedSubtitleModel> = {
     readonly order: number;
 };
 
+type DisplayInterval<T extends IndexedSubtitleModel> = {
+    readonly startMs: number;
+    readonly endMs: number;
+    readonly subtitle: T;
+    readonly order: number;
+};
+
+type DisplayGroup<T extends IndexedSubtitleModel> = {
+    readonly startMs: number;
+    endMs: number;
+    readonly intervals: DisplayInterval<T>[];
+    readonly subtitles: T[];
+};
+
+const maxRenderedSubtitleGroupSize = 4;
+const invisibleSubtitleOverlapToleranceMs = 1;
+
+const overlapsForInvisibleSubtitleGroup = (startMs: number, endMs: number): boolean =>
+    startMs < endMs - invisibleSubtitleOverlapToleranceMs;
+
+const newDisplayGroup = <T extends IndexedSubtitleModel>(
+    startMs: number,
+    intervals: readonly DisplayInterval<T>[]
+): DisplayGroup<T> => ({
+    startMs,
+    endMs: Math.max(...intervals.map(({ endMs }) => endMs)),
+    intervals: [...intervals],
+    subtitles: intervals.map(({ subtitle }) => subtitle),
+});
+
+/** Bounded layout epochs of connected half-open subtitle intervals, ordered by time. */
+const displayGroups = <T extends IndexedSubtitleModel>(
+    intervals: readonly DisplayInterval<T>[]
+): readonly DisplayGroup<T>[] => {
+    const sorted = [...intervals].sort(
+        (left, right) => left.startMs - right.startMs || left.endMs - right.endMs || left.order - right.order
+    );
+    const groups: DisplayGroup<T>[] = [];
+    for (const interval of sorted) {
+        const group = groups.at(-1);
+        if (group === undefined || !overlapsForInvisibleSubtitleGroup(interval.startMs, group.endMs)) {
+            groups.push(newDisplayGroup(interval.startMs, [interval]));
+            continue;
+        }
+
+        const activeIntervals = group.intervals.filter(({ endMs }) =>
+            overlapsForInvisibleSubtitleGroup(interval.startMs, endMs)
+        );
+        if (group.intervals.length < maxRenderedSubtitleGroupSize) {
+            group.endMs = Math.max(group.endMs, interval.endMs);
+            group.intervals.push(interval);
+            group.subtitles.push(interval.subtitle);
+        } else {
+            group.endMs = interval.startMs;
+            groups.push(newDisplayGroup(interval.startMs, [...activeIntervals, interval]));
+        }
+    }
+    return groups;
+};
+
 const eventsFromBlocks = (blocks: readonly PlaybackTimelineBlock[]): readonly PlaybackTimelineEvent[] => {
     const events = blocks.flatMap<PlaybackTimelineEvent>((block) => [
         {
@@ -224,6 +284,7 @@ const compileSegments = <T extends IndexedSubtitleModel>(
     states: readonly PlaybackTimelineState[];
 } => {
     const displayEdges: DisplayEdge<T>[] = [];
+    const displayIntervals: DisplayInterval<T>[] = [];
     const subtitleOrder = new Map<T, number>();
     for (const [order, subtitle] of displaySubtitles.entries()) {
         if (!Number.isFinite(subtitle.start) || !Number.isFinite(subtitle.end) || subtitle.end <= subtitle.start) {
@@ -233,6 +294,7 @@ const compileSegments = <T extends IndexedSubtitleModel>(
         const endMs = clamp(subtitle.end, 0, durationMs);
         if (endMs <= startMs) continue;
         subtitleOrder.set(subtitle, order);
+        displayIntervals.push({ startMs, endMs, subtitle, order });
         displayEdges.push({ timestampMs: startMs, edge: 'start', subtitle, order });
         displayEdges.push({ timestampMs: endMs, edge: 'end', subtitle, order });
     }
@@ -265,6 +327,11 @@ const compileSegments = <T extends IndexedSubtitleModel>(
         displayEdgesByTimestamp.set(edge.timestampMs, values);
     }
 
+    const groups = displayGroups(displayIntervals);
+    for (const group of groups) {
+        group.subtitles.sort((left, right) => (subtitleOrder.get(left) ?? 0) - (subtitleOrder.get(right) ?? 0));
+    }
+    let groupIndex = 0;
     const active = new Set<T>();
     const segments = sortedTimestamps.map<PlaybackTimelineSegment<T>>((startMs) => {
         for (const edge of displayEdgesByTimestamp.get(startMs) ?? []) {
@@ -275,7 +342,13 @@ const compileSegments = <T extends IndexedSubtitleModel>(
         const showingSubtitles = [...active].sort(
             (left, right) => (subtitleOrder.get(left) ?? 0) - (subtitleOrder.get(right) ?? 0)
         );
-        return { startMs, showingSubtitles };
+        while (groupIndex < groups.length && groups[groupIndex].endMs <= startMs) groupIndex++;
+        const group = groups[groupIndex];
+        const invisibleSubtitles =
+            group !== undefined && group.startMs <= startMs && startMs < group.endMs
+                ? group.subtitles.filter((subtitle) => !active.has(subtitle))
+                : [];
+        return { startMs, showingSubtitles, invisibleSubtitles };
     });
 
     let blockIndex = 0;

--- a/common/playback/timeline/playback-timeline.test.ts
+++ b/common/playback/timeline/playback-timeline.test.ts
@@ -86,6 +86,110 @@ describe('PlaybackTimeline', () => {
         expect(result.lookupAt(4000).segment.showingSubtitles).toEqual([]);
     });
 
+    it('provides the inactive members of a fixed connected group as invisible placeholders', () => {
+        const primary = makeSubtitle(1000, 10000, 0, { track: 0 });
+        const firstSecondary = makeSubtitle(2000, 4000, 1, { track: 1 });
+        const secondSecondary = makeSubtitle(6000, 8000, 2, { track: 1 });
+        const result = timeline([], { displaySubtitles: [primary, firstSecondary, secondSecondary] });
+
+        expect(result.invisibleSubtitlesAt(500)).toEqual([]);
+        expect(result.invisibleSubtitlesAt(1000)).toEqual([firstSecondary, secondSecondary]);
+        expect(result.showingSubtitlesAt(1000)).toEqual([primary]);
+        expect(result.invisibleSubtitlesAt(2500)).toEqual([secondSecondary]);
+        expect(result.showingSubtitlesAt(2500)).toEqual([primary, firstSecondary]);
+        expect(result.invisibleSubtitlesAt(4500)).toEqual([firstSecondary, secondSecondary]);
+        expect(result.showingSubtitlesAt(4500)).toEqual([primary]);
+        expect(result.invisibleSubtitlesAt(6500)).toEqual([firstSecondary]);
+        expect(result.showingSubtitlesAt(6500)).toEqual([primary, secondSecondary]);
+        expect(result.invisibleSubtitlesAt(8500)).toEqual([firstSecondary, secondSecondary]);
+        expect(result.showingSubtitlesAt(8500)).toEqual([primary]);
+        expect(result.invisibleSubtitlesAt(10000)).toEqual([]);
+    });
+
+    it('does not create placeholders for temporally disjoint subtitles', () => {
+        const firstTrack = makeSubtitle(1000, 3000, 0, { track: 0 });
+        const secondTrack = makeSubtitle(5000, 7000, 1, { track: 1 });
+        const result = timeline([], { displaySubtitles: [firstTrack, secondTrack] });
+
+        expect(result.showingSubtitlesAt(2000)).toEqual([firstTrack]);
+        expect(result.invisibleSubtitlesAt(2000)).toEqual([]);
+        expect(result.invisibleSubtitlesAt(4000)).toEqual([]);
+        expect(result.showingSubtitlesAt(6000)).toEqual([secondTrack]);
+        expect(result.invisibleSubtitlesAt(6000)).toEqual([]);
+    });
+
+    it('uses the same fixed-group rule for overlapping subtitles on one track', () => {
+        const first = makeSubtitle(2000, 4000, 0, { text: 'ONE', track: 0 });
+        const second = makeSubtitle(3000, 5000, 1, { text: 'HALF', track: 0 });
+        const result = timeline([], { displaySubtitles: [first, second] });
+
+        expect(result.invisibleSubtitlesAt(2500)).toEqual([second]);
+        expect(result.showingSubtitlesAt(2500)).toEqual([first]);
+        expect(result.invisibleSubtitlesAt(3500)).toEqual([]);
+        expect(result.showingSubtitlesAt(3500)).toEqual([first, second]);
+        expect(result.invisibleSubtitlesAt(4500)).toEqual([first]);
+        expect(result.showingSubtitlesAt(4500)).toEqual([second]);
+    });
+
+    it('forms one fixed group through transitive overlaps across multiple tracks', () => {
+        const first = makeSubtitle(1000, 4000, 0, { track: 0 });
+        const second = makeSubtitle(3000, 6000, 1, { track: 1 });
+        const third = makeSubtitle(5000, 8000, 2, { track: 2 });
+        const result = timeline([], { displaySubtitles: [first, second, third] });
+        expect(result.invisibleSubtitlesAt(1500)).toEqual([second, third]);
+        expect(result.showingSubtitlesAt(1500)).toEqual([first]);
+        expect(result.invisibleSubtitlesAt(4500)).toEqual([first, third]);
+        expect(result.showingSubtitlesAt(4500)).toEqual([second]);
+        expect(result.invisibleSubtitlesAt(6500)).toEqual([first, second]);
+        expect(result.showingSubtitlesAt(6500)).toEqual([third]);
+    });
+
+    it('does not form a fixed group through transitive 1 ms overlaps', () => {
+        const subtitles = Array.from({ length: 20 }, (_, index) =>
+            makeSubtitle(index * 999, index * 999 + 1000, index)
+        );
+        const result = timeline([], { durationMs: 20_000, displaySubtitles: subtitles });
+
+        expect(result.invisibleSubtitlesAt(500)).toEqual([]);
+        expect(result.showingSubtitlesAt(999)).toEqual(subtitles.slice(0, 2));
+        expect(result.invisibleSubtitlesAt(1500)).toEqual([]);
+        expect(result.invisibleSubtitlesAt(19_000)).toEqual([]);
+    });
+
+    it('starts a canonically ordered layout epoch when a fifth transitive subtitle enters', () => {
+        const subtitles = Array.from({ length: 5 }, (_, index) =>
+            makeSubtitle(1000 + index * 1000, 3000 + index * 1000, index, { track: index % 2 })
+        );
+        const result = timeline([], { displaySubtitles: subtitles });
+
+        expect(result.invisibleSubtitlesAt(4500)).toEqual(subtitles.slice(0, 2));
+        expect(result.showingSubtitlesAt(4500)).toEqual(subtitles.slice(2, 4));
+        expect(result.invisibleSubtitlesAt(5000)).toEqual([]);
+        expect(result.showingSubtitlesAt(5000)).toEqual(subtitles.slice(3, 5));
+    });
+
+    it('renders every subtitle when more than four are genuinely visible simultaneously', () => {
+        const subtitles = Array.from({ length: 5 }, (_, index) =>
+            makeSubtitle(1000, 3000, index, { track: index % 2 })
+        );
+        const result = timeline([], { displaySubtitles: subtitles });
+
+        expect(result.invisibleSubtitlesAt(1500)).toEqual([]);
+        expect(result.showingSubtitlesAt(1500)).toEqual(subtitles);
+    });
+
+    it('bounds future placeholders when four persistent subtitles remain active', () => {
+        const persistent = Array.from({ length: 4 }, (_, index) => makeSubtitle(0, 60000, index));
+        const sequential = Array.from({ length: 100 }, (_, index) =>
+            makeSubtitle(1000 + index * 500, 1400 + index * 500, persistent.length + index)
+        );
+        const result = timeline([], { displaySubtitles: [...persistent, ...sequential] });
+
+        expect(result.showingSubtitlesAt(10)).toEqual(persistent);
+        expect(result.invisibleSubtitlesAt(10)).toEqual([]);
+        expect(Math.max(...result.segments.map(({ invisibleSubtitles }) => invisibleSubtitles.length))).toBe(1);
+    });
+
     it('uses the state after the terminal boundary at the exact media duration', () => {
         const visible = makeSubtitle(9000, 10000, 0);
         const result = timeline([visible]);

--- a/common/playback/timeline/playback-timeline.ts
+++ b/common/playback/timeline/playback-timeline.ts
@@ -52,6 +52,8 @@ export interface PlaybackTimelineBlock {
 export interface PlaybackTimelineSegment<T extends IndexedSubtitleModel> {
     readonly startMs: number;
     readonly showingSubtitles: readonly T[];
+    /** Invisible placeholders mounted to keep overlapping tracks stable. */
+    readonly invisibleSubtitles: readonly T[];
     readonly condensedTarget?: number;
     readonly nextStartActionTimestamp?: number;
 }
@@ -136,6 +138,10 @@ export default class PlaybackTimeline<T extends IndexedSubtitleModel> {
 
     showingSubtitlesAt(timestampMs: number): readonly T[] {
         return this.lookupAt(timestampMs).segment.showingSubtitles;
+    }
+
+    invisibleSubtitlesAt(timestampMs: number): readonly T[] {
+        return this.lookupAt(timestampMs).segment.invisibleSubtitles;
     }
 
     blockById(blockId: string): PlaybackTimelineBlock | undefined {

--- a/common/src/message.ts
+++ b/common/src/message.ts
@@ -394,6 +394,7 @@ export interface PlaybackStateFromVideoMessage extends Message {
     readonly command: 'playbackState';
     readonly timestampMs: number;
     readonly showingSubtitleIndexes: readonly number[];
+    readonly invisibleSubtitleIndexes?: readonly number[];
     readonly hiddenSubtitleIndexes?: readonly number[];
     readonly paused: boolean;
 }

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -66,7 +66,11 @@ export interface IndexedSubtitleModel extends SubtitleModel {
 
 export interface PlaybackState {
     readonly timestampMs: number;
+    /** Indexes of subtitles currently being shown on the screen. */
     readonly showingSubtitleIndexes: readonly number[];
+    /** Indexes of invisible layout placeholders. Absent when empty. */
+    readonly invisibleSubtitleIndexes?: readonly number[];
+    /** Indexes suppressed from rendering by user preference. Absent when empty. */
     readonly hiddenSubtitleIndexes?: readonly number[];
     readonly paused: boolean;
 }

--- a/common/util/util.test.ts
+++ b/common/util/util.test.ts
@@ -20,6 +20,7 @@ import {
     hex2ToPercent,
     hexToRgb,
     humanReadableTime,
+    mapSubtitlesForDisplay,
     inBatches,
     isKanaOnly,
     isKanaMoraPitchHigh,
@@ -1172,5 +1173,23 @@ it('sorts subtitles by track first, regardless of source index', () => {
     expect([...cues].sort(compareSubtitlesForDisplay)).toEqual([
         { track: 0, index: 1 },
         { track: 1, index: 0 },
+    ]);
+});
+
+it('maps showing and invisible subtitles in display order with their visibility', () => {
+    const showing = [
+        { track: 0, index: 1 },
+        { track: 2, index: 0 },
+    ];
+    const invisible = [
+        { track: 1, index: 3 },
+        { track: 2, index: 2 },
+    ];
+
+    expect(mapSubtitlesForDisplay(showing, invisible, (subtitle, visible) => ({ ...subtitle, visible }))).toEqual([
+        { track: 0, index: 1, visible: true },
+        { track: 1, index: 3, visible: false },
+        { track: 2, index: 0, visible: true },
+        { track: 2, index: 2, visible: false },
     ]);
 });

--- a/common/util/util.ts
+++ b/common/util/util.ts
@@ -51,6 +51,32 @@ export function compareSubtitlesForDisplay(
     return s1.track - s2.track || (s1.index ?? 0) - (s2.index ?? 0);
 }
 
+/** Maps separately sorted showing and invisible subtitles into canonical display order. */
+export function mapSubtitlesForDisplay<T extends Pick<SubtitleModel, 'track' | 'index'>, R>(
+    showingSubtitles: readonly T[],
+    invisibleSubtitles: readonly T[],
+    map: (subtitle: T, visible: boolean, sourceIndex: number) => R
+): R[] {
+    const result: R[] = [];
+    let showingIndex = 0;
+    let invisibleIndex = 0;
+    while (showingIndex < showingSubtitles.length || invisibleIndex < invisibleSubtitles.length) {
+        const showingSubtitle = showingSubtitles[showingIndex];
+        const invisibleSubtitle = invisibleSubtitles[invisibleIndex];
+        if (
+            invisibleSubtitle === undefined ||
+            (showingSubtitle !== undefined && compareSubtitlesForDisplay(showingSubtitle, invisibleSubtitle) < 0)
+        ) {
+            result.push(map(showingSubtitle, true, showingIndex));
+            showingIndex++;
+        } else {
+            result.push(map(invisibleSubtitle, false, invisibleIndex));
+            invisibleIndex++;
+        }
+    }
+    return result;
+}
+
 export function keysAreEqual(a: any, b: any) {
     const aKeys = Object.keys(a);
     const bKeys = Object.keys(b);

--- a/extension/src/controllers/subtitle-controller.test.ts
+++ b/extension/src/controllers/subtitle-controller.test.ts
@@ -132,4 +132,143 @@ describe('SubtitleController appearance rendering', () => {
             'color: #0000ff'
         );
     });
+
+    it('renders layout placeholders invisibly and supports playback states from older clients', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings(defaultSettings);
+        controller.subtitles = [
+            {
+                text: 'primary',
+                start: 0,
+                end: 3000,
+                originalStart: 0,
+                originalEnd: 3000,
+                track: 0,
+                index: 0,
+            },
+            {
+                text: 'secondary',
+                start: 1000,
+                end: 2000,
+                originalStart: 1000,
+                originalEnd: 2000,
+                track: 1,
+                index: 1,
+            },
+        ];
+        controller.cacheHtml();
+
+        controller.playbackStateChanged({
+            timestampMs: 0,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            paused: false,
+        });
+
+        const secondary = document.querySelector<HTMLElement>('span[data-track="1"]')?.parentElement;
+        const container = document.querySelector<HTMLElement>('.asbplayer-subtitles-container-bottom');
+        const primary = document.querySelector<HTMLElement>('span[data-track="0"]')?.parentElement;
+        expect(container?.style.getPropertyValue('pointer-events')).toBe('none');
+        expect(primary?.style.pointerEvents).toBe('auto');
+        expect(secondary?.style.visibility).toBe('hidden');
+        expect(secondary?.style.pointerEvents).toBe('none');
+        expect(secondary?.getAttribute('aria-hidden')).toBe('true');
+
+        controller.playbackStateChanged({ timestampMs: 1000, showingSubtitleIndexes: [0, 1], paused: false });
+
+        expect(document.querySelector<HTMLElement>('span[data-track="1"]')?.parentElement?.style.visibility).toBe('');
+    });
+
+    it('excludes invisible layout placeholders from hover hit testing', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings(defaultSettings);
+        controller.subtitles = [
+            {
+                text: 'visible',
+                start: 0,
+                end: 3000,
+                originalStart: 0,
+                originalEnd: 3000,
+                track: 0,
+                index: 0,
+            },
+            {
+                text: 'placeholder',
+                start: 1000,
+                end: 2000,
+                originalStart: 1000,
+                originalEnd: 2000,
+                track: 1,
+                index: 1,
+            },
+        ];
+        controller.cacheHtml();
+        controller.playbackStateChanged({
+            timestampMs: 0,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            paused: false,
+        });
+
+        const container = document.querySelector<HTMLElement>('.asbplayer-subtitles-container-bottom')!;
+        const visible = document.querySelector<HTMLElement>('span[data-track="0"]')!.parentElement!;
+        const placeholder = document.querySelector<HTMLElement>('span[data-track="1"]')!.parentElement!;
+        container.getBoundingClientRect = () => ({ x: 100, y: 100, width: 100, height: 80 }) as DOMRect;
+        visible.getBoundingClientRect = () => ({ x: 100, y: 100, width: 100, height: 20 }) as DOMRect;
+        placeholder.getBoundingClientRect = () => ({ x: 100, y: 140, width: 100, height: 20 }) as DOMRect;
+
+        expect(controller.intersects(110, 110)).toBe(true);
+        expect(controller.intersects(110, 155)).toBe(false);
+    });
+
+    it('filters hidden subtitles without removing unhidden layout placeholders', () => {
+        const controller = controllerForVideo();
+        controller.setSubtitleSettings(defaultSettings);
+        controller.subtitles = [
+            {
+                text: 'primary',
+                start: 0,
+                end: 3000,
+                originalStart: 0,
+                originalEnd: 3000,
+                track: 0,
+                index: 0,
+            },
+            {
+                text: 'placeholder',
+                start: 1000,
+                end: 2000,
+                originalStart: 1000,
+                originalEnd: 2000,
+                track: 1,
+                index: 1,
+            },
+        ];
+        controller.cacheHtml();
+
+        controller.playbackStateChanged({
+            timestampMs: 0,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            hiddenSubtitleIndexes: [0],
+            paused: false,
+        });
+
+        const container = document.querySelector('.asbplayer-subtitles-container-bottom');
+        expect(container?.querySelector('span[data-track="0"]')).toBeNull();
+        expect(container?.querySelector<HTMLElement>('span[data-track="1"]')?.parentElement?.style.visibility).toBe(
+            'hidden'
+        );
+
+        controller.playbackStateChanged({
+            timestampMs: 0,
+            showingSubtitleIndexes: [0],
+            invisibleSubtitleIndexes: [1],
+            hiddenSubtitleIndexes: [0, 1],
+            paused: false,
+        });
+
+        expect(container?.querySelector('span[data-track="0"]')).toBeNull();
+        expect(container?.querySelector('span[data-track="1"]')).toBeNull();
+    });
 });

--- a/extension/src/controllers/subtitle-controller.ts
+++ b/extension/src/controllers/subtitle-controller.ts
@@ -31,6 +31,7 @@ import {
     compareSubtitlesForDisplay,
     computeStyleString,
     formatAsSignedMs,
+    mapSubtitlesForDisplay,
     surroundingSubtitles,
 } from '@project/common/util';
 import i18n from 'i18next';
@@ -49,6 +50,15 @@ const _intersects = (clientX: number, clientY: number, element: HTMLElement): bo
         clientX <= rect.x + rect.width + BOUNDING_BOX_PADDING &&
         clientY >= rect.y - BOUNDING_BOX_PADDING &&
         clientY <= rect.y + rect.height + BOUNDING_BOX_PADDING
+    );
+};
+
+const _intersectsVisibleChild = (clientX: number, clientY: number, element: HTMLElement): boolean => {
+    return [...element.children].some(
+        (child) =>
+            child instanceof HTMLDivElement &&
+            child.style.visibility !== 'hidden' &&
+            _intersects(clientX, clientY, child)
     );
 };
 
@@ -80,7 +90,9 @@ export default class SubtitleController {
     private readonly settings: SettingsProvider;
 
     private showingSubtitles?: IndexedSubtitleModel[];
+    private invisibleSubtitles?: IndexedSubtitleModel[];
     private timelineShowingSubtitles: readonly IndexedSubtitleModel[] = [];
+    private timelineInvisibleSubtitles: readonly IndexedSubtitleModel[] = [];
     private lastOffsetChangeTimestamp: number;
     private showingOffset?: number;
     private loadedMessageHideTimeout?: ReturnType<typeof setTimeout>;
@@ -169,7 +181,9 @@ export default class SubtitleController {
         this.subtitles = [];
         this.subtitleFileNames = undefined;
         this.timelineShowingSubtitles = [];
+        this.timelineInvisibleSubtitles = [];
         this.showingSubtitles = undefined;
+        this.invisibleSubtitles = undefined;
         this.showingLoadedMessage = false;
         if (this.loadedMessageHideTimeout) clearTimeout(this.loadedMessageHideTimeout);
         this.loadedMessageHideTimeout = undefined;
@@ -391,7 +405,10 @@ export default class SubtitleController {
                 ) {
                     this.topSubtitlesElementOverlay.cacheHtml(html.key, html.html());
                 }
-                if (this.showingSubtitles?.some((s) => s.index === updatedSubtitle.index)) {
+                if (
+                    this.showingSubtitles?.some((s) => s.index === updatedSubtitle.index) ||
+                    this.invisibleSubtitles?.some((s) => s.index === updatedSubtitle.index)
+                ) {
                     this.refreshCurrentSubtitle = true;
                 }
             }
@@ -418,6 +435,10 @@ export default class SubtitleController {
             .filter((index) => !hiddenSubtitleIndexes.includes(index))
             .map((index) => this.subtitles[index])
             .filter((subtitle): subtitle is IndexedSubtitleModel => subtitle !== undefined);
+        this.timelineInvisibleSubtitles = (state.invisibleSubtitleIndexes ?? [])
+            .filter((index) => !hiddenSubtitleIndexes.includes(index))
+            .map((index) => this.subtitles[index])
+            .filter((subtitle): subtitle is IndexedSubtitleModel => subtitle !== undefined);
         this.refreshShowingSubtitles();
     }
 
@@ -428,14 +449,23 @@ export default class SubtitleController {
             .filter((subtitle) => this._trackEnabled(subtitle))
             .slice()
             .sort(compareSubtitlesForDisplay);
-        const subtitlesAreNew =
+        const invisibleSubtitles = this.timelineInvisibleSubtitles
+            .filter((subtitle) => this._trackEnabled(subtitle))
+            .slice()
+            .sort(compareSubtitlesForDisplay);
+        const showingSubtitlesAreNew =
             this.showingSubtitles === undefined ||
             !arrayEquals(showingSubtitles, this.showingSubtitles, (left, right) => left.index === right.index);
+        const invisibleSubtitlesAreNew =
+            this.invisibleSubtitles === undefined ||
+            !arrayEquals(invisibleSubtitles, this.invisibleSubtitles, (left, right) => left.index === right.index);
+        const subtitlesAreNew = showingSubtitlesAreNew || invisibleSubtitlesAreNew;
 
-        if (subtitlesAreNew) {
+        if (showingSubtitlesAreNew) {
             this.showingSubtitles = showingSubtitles;
             this._autoCopyToClipboard(showingSubtitles);
         }
+        if (invisibleSubtitlesAreNew) this.invisibleSubtitles = invisibleSubtitles;
 
         const showOffset = this.lastOffsetChangeTimestamp > 0 && Date.now() - this.lastOffsetChangeTimestamp < 1000;
         const offset = showOffset ? this._computeOffset() : 0;
@@ -454,12 +484,14 @@ export default class SubtitleController {
         if (this.shouldRenderBottomOverlay) {
             this._renderSubtitles(
                 showingSubtitles.filter((subtitle) => this._getSubtitleTrackAlignment(subtitle.track) === 'bottom'),
+                invisibleSubtitles.filter((subtitle) => this._getSubtitleTrackAlignment(subtitle.track) === 'bottom'),
                 OffsetAnchor.bottom
             );
         }
         if (this.shouldRenderTopOverlay) {
             this._renderSubtitles(
                 showingSubtitles.filter((subtitle) => this._getSubtitleTrackAlignment(subtitle.track) === 'top'),
+                invisibleSubtitles.filter((subtitle) => this._getSubtitleTrackAlignment(subtitle.track) === 'top'),
                 OffsetAnchor.top
             );
         }
@@ -472,11 +504,21 @@ export default class SubtitleController {
         }
     }
 
-    private _renderSubtitles(subtitles: IndexedSubtitleModel[], offset: OffsetAnchor) {
+    private _renderSubtitles(
+        showingSubtitles: IndexedSubtitleModel[],
+        invisibleSubtitles: IndexedSubtitleModel[],
+        offset: OffsetAnchor
+    ) {
+        const showingHtml = this._buildSubtitlesHtml(showingSubtitles);
+        const invisibleHtml = this._buildSubtitlesHtml(invisibleSubtitles);
+        const html = mapSubtitlesForDisplay(showingSubtitles, invisibleSubtitles, (_, visible, sourceIndex) => ({
+            ...(visible ? showingHtml[sourceIndex] : invisibleHtml[sourceIndex]),
+            visible,
+        }));
         if (offset == OffsetAnchor.top) {
-            this._setSubtitlesHtml(this.topSubtitlesElementOverlay, this._buildSubtitlesHtml(subtitles));
+            this._setSubtitlesHtml(this.topSubtitlesElementOverlay, html);
         } else {
-            this._setSubtitlesHtml(this.bottomSubtitlesElementOverlay, this._buildSubtitlesHtml(subtitles));
+            this._setSubtitlesHtml(this.bottomSubtitlesElementOverlay, html);
         }
     }
 
@@ -815,13 +857,13 @@ export default class SubtitleController {
     intersects(clientX: number, clientY: number): boolean {
         const bottomContainer = this.bottomSubtitlesElementOverlay.containerElement;
 
-        if (bottomContainer !== undefined && _intersects(clientX, clientY, bottomContainer)) {
+        if (bottomContainer !== undefined && _intersectsVisibleChild(clientX, clientY, bottomContainer)) {
             return true;
         }
 
         const topContainer = this.topSubtitlesElementOverlay.containerElement;
 
-        if (topContainer !== undefined && _intersects(clientX, clientY, topContainer)) {
+        if (topContainer !== undefined && _intersectsVisibleChild(clientX, clientY, topContainer)) {
             return true;
         }
 

--- a/extension/src/services/binding.ts
+++ b/extension/src/services/binding.ts
@@ -430,7 +430,7 @@ export default class Binding {
         return new PlaybackEngine({
             settingsProvider: this.settings,
             appIntegration: true,
-            autoPauseCorrectionSuppressed: disneyPlus,
+            autoPauseCorrectionDisabled: disneyPlus,
             subtitles,
             playbackModesDisabled: false,
             playbackModesSuppressed: this.recordingMedia,

--- a/extension/src/services/element-overlay.test.ts
+++ b/extension/src/services/element-overlay.test.ts
@@ -132,6 +132,41 @@ describe('CachingElementOverlay fullscreen transitions', () => {
         overlay.dispose();
     });
 
+    it('selects a fullscreen player parent when the overlay container ignores pointer events', () => {
+        const fullscreenRoot = document.createElement('div');
+        const videoParent = document.createElement('div');
+        const targetElement = document.createElement('video');
+        fullscreenRoot.appendChild(videoParent);
+        videoParent.appendChild(targetElement);
+        document.body.appendChild(fullscreenRoot);
+        videoParent.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 500 }) as DOMRect;
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => {
+                const probe = videoParent.lastElementChild as HTMLElement;
+                return probe.style.pointerEvents === 'none' ? targetElement : probe;
+            },
+        });
+
+        const overlay = new CachingElementOverlay({
+            targetElement,
+            nonFullscreenContainerClassName: 'non-fullscreen-container',
+            nonFullscreenContentClassName: 'non-fullscreen-content',
+            fullscreenContainerClassName: 'fullscreen-container',
+            fullscreenContentClassName: 'fullscreen-content',
+            offsetAnchor: OffsetAnchor.bottom,
+            onMouseOver: () => {},
+            onMouseOut: () => {},
+        });
+        overlay.setHtml([{ key: 'subtitle', html: () => '<span>subtitle</span>' }]);
+
+        fullscreenElement = fullscreenRoot;
+        document.dispatchEvent(new Event('fullscreenchange'));
+
+        expect(videoParent.querySelector('.fullscreen-container')).not.toBeNull();
+        overlay.dispose();
+    });
+
     it('accounts for horizontal and vertical document scrolling outside fullscreen', () => {
         const originalScrollX = Object.getOwnPropertyDescriptor(window, 'scrollX');
         const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');

--- a/extension/src/services/element-overlay.ts
+++ b/extension/src/services/element-overlay.ts
@@ -8,6 +8,7 @@ export enum OffsetAnchor {
 export interface KeyedHtml {
     key?: string;
     html: () => string;
+    visible?: boolean;
 }
 
 export interface ElementOverlayParams {
@@ -161,7 +162,7 @@ export class CachingElementOverlay implements ElementOverlay {
     }
 
     private _displayNonFullscreenContentElementsWithHtml(htmls: KeyedHtml[]) {
-        this._displayNonFullscreenContentElements(htmls.map((html) => this._cachedContentElement(html.html, html.key)));
+        this._displayNonFullscreenContentElements(this._contentElementsWithHtml(htmls));
     }
 
     private _displayNonFullscreenContentElements(contentElements: HTMLElement[]) {
@@ -175,7 +176,18 @@ export class CachingElementOverlay implements ElementOverlay {
     }
 
     private _displayFullscreenContentElementsWithHtml(htmls: KeyedHtml[]) {
-        this._displayFullscreenContentElements(htmls.map((html) => this._cachedContentElement(html.html, html.key)));
+        this._displayFullscreenContentElements(this._contentElementsWithHtml(htmls));
+    }
+
+    private _contentElementsWithHtml(htmls: KeyedHtml[]): HTMLElement[] {
+        return htmls.map((html) => {
+            const element = this._cachedContentElement(html.html, html.key);
+            const visible = html.visible !== false;
+            element.style.visibility = visible ? '' : 'hidden';
+            element.style.pointerEvents = visible ? 'auto' : 'none';
+            element.setAttribute('aria-hidden', String(!visible));
+            return element;
+        });
     }
 
     private _displayFullscreenContentElements(contentElements: HTMLElement[]) {
@@ -195,6 +207,7 @@ export class CachingElementOverlay implements ElementOverlay {
 
         const container = document.createElement('div');
         container.className = this.nonFullscreenContainerClassName;
+        container.style.setProperty('pointer-events', 'none', 'important');
         container.onmouseover = this.onMouseOver;
         container.onmouseout = this.onMouseOut;
         document.body.appendChild(container);
@@ -240,6 +253,7 @@ export class CachingElementOverlay implements ElementOverlay {
 
         const container = document.createElement('div');
         container.className = this.fullscreenContainerClassName;
+        container.style.setProperty('pointer-events', 'none', 'important');
         container.onmouseover = this.onMouseOver;
         container.onmouseout = this.onMouseOut;
         this._findFullscreenParentElement(container).appendChild(container);
@@ -291,6 +305,7 @@ export class CachingElementOverlay implements ElementOverlay {
 
     private _findFullscreenParentElement(container: HTMLElement): HTMLElement {
         const testNode = container.cloneNode(true) as HTMLElement;
+        testNode.style.setProperty('pointer-events', 'auto', 'important');
         testNode.innerHTML = '&nbsp;'; // The node needs to take up some space to perform test clicks
         let current = this.targetElement.parentElement;
 


### PR DESCRIPTION
fixes #628

This addresses the issue where overlapping subtitles with different timestamps causes subtitles to jump around. This can be between two tracks (as in the issue), or even on the same track with multiple lines.

The best way I think of solving this is rendering the overlapping subtitles as invisible placeholders and make them visible when it's time for them to be shown. This lets the browser handles all the rendering details without us trying to manual position subtitles which seems like a nightmare. These invisible subtitles also have no pointer events and does not affect auto copying, seeking, or playback modes. They also don't apply to the subtitle list.

I'm sending a separate array through `PlaybackState` with the invisible subtitles indexes, these are calculated when the timeline is compiled like the showing subtitles. This along with the hidden indexes allows the consumers to choose what they care about and can easily apply their own semantics.

There are a couple edge cases worth discussing:
- We need a limit to the overlapping subtitles we group together so that say 10 overlapping subtitles aren't rendered offscreen. I've set this to four (which covers an overlap for bottom and top subtitles) and if more that 4 overlaps are happening at once, they revert to the behavior in the issue. This is a compromise between stable layouts and unrealistic cases.
- I also added a small overlap tolerance of `1ms`, so that subtitles overlapping by `1ms` isn't considered overlapping. This is a speculative defense against bad subtitles where each event is overlapping by `1ms` due to an off by one error when generating the subtitles. This has no visual impact on asbplayer since the frames of a video is unlikely to land here but prevents activating the placeholder logic when there is only ever 1 event on screen at a time.
- For an edge case I didn't deem worth fixing, we could have unnecessary placeholders when a 3+ overlap group only has two subtitles displaying at the same time. So a long event A that spans B and C will have 3 slots even though B and C may not overlap and we can make do with 2 slots. This is a minor thing which requires a lot of complexity or a different design to solve.

Here is an SRT which covers the behaviors, I recommend testing on the live web app at the same time for an easy comparison as well as loading this same SRT into track 1 and track 2 with bottom and top alignments to see how it behaves with two tracks:
```
1
00:00:02,000 --> 00:00:04,000
ONE

2
00:00:03,000 --> 00:00:05,000
TWO

3
00:00:05,000 --> 00:00:06,000
THREE

4
00:00:08,000 --> 00:00:10,000
FOUR

5
00:00:14,000 --> 00:00:19,000
FIVE

6
00:00:15,000 --> 00:00:17,000
SIX

7
00:00:18,000 --> 00:00:20,000
SEVEN

8
00:00:21,000 --> 00:00:27,000
EIGHT

9
00:00:22,000 --> 00:00:30,000
NINE

10
00:00:23,000 --> 00:00:29,000
TEN

11
00:00:24,000 --> 00:00:30,000
ELEVEN

12
00:00:25,000 --> 00:00:28,000
TWELVE

13
00:00:26,000 --> 00:00:30,000
THIRTEEN
```

- [x] I have read the [contribution guidelines](https://github.com/asbplayer/asbplayer/blob/main/CONTRIBUTING.md).

Assisted-by: Codex(VSCode):GPT-5.6
